### PR TITLE
Fix declining creating indexes still starts indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## Unreleased
 
 ### Fixed
- - `gens index` command now respect the answer the confirmation prompt.
+ - `gens index` command now respects the answer of the confirmation prompt.
 
 ## 3.0.0 - Merging Solnas and Lunds changes
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Fixed
+ - `gens index` command now respect the answer the confirmation prompt.
+
 ## 3.0.0 - Merging Solnas and Lunds changes
 ### Added
  - `--force` flag to `gens loads sample` for overwriting any existing sample in case of key conflict.

--- a/gens/commands/index.py
+++ b/gens/commands/index.py
@@ -13,22 +13,28 @@ LOG = logging.getLogger(__name__)
 
 @click.command("index", short_help="Index the database")
 @click.option(
+    "-y",
     "--yes",
+    "build",
     is_flag=True,
-    required=True,
-    prompt="This will delete and rebuild all indexes(if not --update). Are you sure?",
 )
-@click.option("--update", help="Update the indexes", is_flag=True)
+@click.option("-u", "--update", help="Update the indexes", is_flag=True)
 @with_appcontext
-def index(yes, update):
+def index(build, update):
     """Create indexes for the database."""
-    LOG.info("Creating indexes for the database.")
     db = current_app.config["GENS_DB"]
 
     if update:
         n_updated = update_indexes(db)
         if n_updated == 0:
             click.secho("All indexes in place, nothing updated", fg="green")
-    else:
+        return
+
+    # ask for confirmation to index if --yes is not set
+    shall_index = False
+    if not build:
+        shall_index = click.confirm("This will delete and rebuild all indexes(if not --update). Are you sure?")
+
+    if shall_index or build:
         create_indexes(db)
         click.secho("New indexes created", fg="green")

--- a/gens/db/index.py
+++ b/gens/db/index.py
@@ -113,13 +113,14 @@ def create_index(db, collection_name):
 
 def create_indexes(db):
     """Create indexes for Gens db."""
+    LOG.info("Indexing the gens database.")
     for collection_name in INDEXES:
         create_index(db, collection_name)
 
 
 def update_indexes(db):
     """Add missing indexes to the database."""
-    LOG.info("Updating indexes.")
+    LOG.info("Updating gens database indexes.")
     n_updated = 0
     for collection_name, indexes in INDEXES.items():
         existing_indexes = get_indexes(db, collection_name)
@@ -129,5 +130,5 @@ def update_indexes(db):
                 LOG.info(f"Creating index : {index_name}")
                 db[collection_name].create_indexes([index])
                 n_updated += 1
-    LOG.info(f"Updated {n_updated} indexes to the database")
+    LOG.info("Updated %d indexes to the database", n_updated)
     return n_updated


### PR DESCRIPTION
This PR fixes an issue where `gens index` did not respect a negative answer to the confirmation to reindex the database.