### PR TITLE
Opening a sample without a case id causes endless loading of the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 #### Changed
  - Added files for setting up development and deployment-like instances.
+ - Throw a error when trying to open a sample without providing a case id.
 
 ### Fixed
  - Fixed issue that prevented parsing of bed files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 #### Changed
  - Added files for setting up development and deployment-like instances.
- - Throw a error when trying to open a sample without providing a case id.
+ - Throw an error when trying to open a sample without providing a case id.
 
 ### Fixed
  - Fixed issue that prevented parsing of bed files.

--- a/gens/blueprints/gens/views.py
+++ b/gens/blueprints/gens/views.py
@@ -28,7 +28,9 @@ def display_case(sample_name):
     Renders the Gens template
     Expects sample_id as input to be able to load the sample data
     """
-    case_id = request.args.get("case_id", None)
+    case_id = request.args.get("case_id")
+    if case_id is None:
+        raise ValueError("You must provide a case id when opening a sample.")
     individual_id = request.args.get("individual_id", sample_name)
     
     # get genome build and region


### PR DESCRIPTION
Gens now throws a error when trying to open a sample without providing a case id.

![bild](https://github.com/user-attachments/assets/67aac579-5092-409f-93f1-76096dda7bb8)
