### PR TITLE
231 returned data without declaring it first in get multiple coverages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Switched from JS to TS and updated required parts of the build chain.
 
 ### Fixed
+ - Minor cleanup of `get-multiple-coverages` function.
  - Resolved all type errors from tsc
  - Initial type hints added to command and db modules
  - Remove unused file argument for load chromomsome info CLI command

--- a/gens/api.py
+++ b/gens/api.py
@@ -213,12 +213,9 @@ def get_variant_data(case_id, sample_id, variant_category, **optional_kwargs):
     )
 
 
-def get_multiple_coverages() -> dict[str, Any]:
+def get_multiple_coverages() -> dict[str, Any] | tuple[Any, int]:
     """Read default Log2 ratio and BAF values for overview graph."""
-    if connexion.request.is_json:
-        data = QueryChromosomeCoverage(**connexion.request.get_json())
-    else:
-        return data, 404
+    data = QueryChromosomeCoverage(**connexion.request.get_json())
     LOG.info("Got request for all chromosome coverages: %s", data.sample_id)
 
     # read sample information


### PR DESCRIPTION
This PR just remove some code that dont seem to do anything since the data passed to the API entrypoint is validated by connexion.

When passed invalid json

```
$ curl 'http://localhost:8080/api/get-multiple-coverages' -X POST -H 'Content-Type: application/json' --data-raw 'abc'

{
  "detail": "Request body is not valid JSON",
  "status": 400,
  "title": "Bad Request",
  "type": "about:blank"
}
```

When post incomplete request
```
$ curl 'http://localhost:8080/api/get-multiple-coverages' -X POST -H 'Content-Type: application/json' --data-raw '{"foo": "bar"}'

# cause validation errors
pydantic_core._pydantic_core.ValidationError: 12 validation errors for QueryChromosomeCoverage
```

When passed non-json data (application/x-www-form-urlencoded content type)

```
curl 'http://localhost:8080/api/get-multiple-coverages' -X POST -H 'Content-Type: application/x-www-form-urlencoded' --data-raw 'foo=bar!'
{
  "detail": "Invalid Content-type (application/data), expected JSON data",
  "status": 415,
  "title": "Unsupported Media Type",
  "type": "about:blank"
}
```****