### PR TITLE
Add option to configure Gens with toml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## Unreleased
 
 ### Added
+ - User can specify path to a custom config file with the env `CONFIG_FILE`.
  - Added test for the cli command `gens load annotations`.
  - Use pydantic-settings for settings validation.
  - Add linting to CI github workflow
@@ -14,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - load transcripts can also read gzipped files
 
 ### Changed
- - Changed some settings names
+ - Settings now uses submodels for oauth and database connections
  - Migrated from setup.py to pyproject.toml using hatchling
  - Updated python to version 3.12 and thawed some dependencies.
  - Switched from JS to TS and updated required parts of the build chain.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This screenshot shows an 8 Kbp deletion (known polymorphism). Sorry about the bo
 
 ## Installation
 
-Gens requires python 3.5 or later and mongodb. For testing/development purposes the easiest way to install it is to create a virtual environment:
+Gens requires python 3.11 or later and mongodb. For testing/development purposes the easiest way to install it is to create a virtual environment:
 
 ``` bash
 git clone https://github.com/Clinical-Genomics-Lund/Gens.git

--- a/README.md
+++ b/README.md
@@ -83,6 +83,57 @@ gens load transcripts --file Homo_sapiens.GRCh38.113.gtf.gz --mane MANE.GRCh38.v
 
 Annotated regions can be loaded into the database in either `bed` or `aed` format.
 
+### Configuration
+
+The behaviour of Gens and the connections to the mongo databases can be configured in several ways. The software can be configured using environment variables, a dotfile or with a separate toml file. To use a custom toml file the user have to specify the path to the file with the environment variable CONIFG_FILE and ensure that file is readable by the gens executable.
+
+The configs are read in the following priority order,
+
+1.	Environment variables
+2.	Dotfile
+3.	Custom toml
+4.	Default configuration (stored in config.toml)
+
+Example of how to use environment variables in combination with docker.
+
+```yaml
+services:
+  gens:
+    environment:
+      - GENS_DB__CONNECTION=mongodb://mongodb:27017/"
+```
+
+Example of how-to setup Gens with a custom configuration in a docker environment.
+
+```yaml
+services:
+  gens:
+    environment:
+      - CONFIG_FILE=/home/worker/user.conf.toml
+    volumes:
+      - ./user.conf.toml:/home/worker/user.conf.toml
+```
+
+#### Options
+
+Configuration options. Note that double underscores (`__`) are used to denote sub-categories, such as **gens_db** and **oauth**, when using environment variables. For example, the envionment variable name for configuring Gens mongodb connection is `GENS_DB__CONNECTION` (`<SUB-CATEGORY>__<VARIABLE>`).
+
+- **scout_url**, base url to Scout.
+
+##### gens_db
+
+Connection to the Gens mongo database.
+
+- **connection**, mongodb conneciton string
+- **database**, optional database name. Can also be in connection string
+
+##### scout_db
+
+Connection to the Scout mongo database.
+
+- **connection**, mongodb conneciton string
+- **database**, optional database name. Can also be in connection string
+
 ## Data generation
 
 Gens uses a custom tabix-indexed bed file format to hold the plot data. This file can be generated in any way, as long as the format of the file is according to the specification (see the section "Data format"). This section describes the method we're using to create the data.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,6 @@ services:
     volumes:
       - ./volumes/gens/data:/home/app/data
       - ./volumes/gens/wgs:/home/app/access/wgs
-    environment:
-      - MONGODB_HOST=mongodb
-      - MONGODB_PORT=27017
-      - SCOUT_DBNAME=scout
-      - GENS_DBNAME=gens
     expose:
       - '5000'
     ports:

--- a/gens/commands/load.py
+++ b/gens/commands/load.py
@@ -158,7 +158,7 @@ def sample(
 )
 def annotations(file: str, genome_build: GenomeBuild, has_header: bool):
     """Load annotations from file into the database."""
-    db = get_db_connection(settings.gens_db, db_name=settings.gens_dbname)
+    db = get_db_connection(settings.gens_db.connection, db_name=settings.gens_db.database)
     # if collection is not indexed, create index
     if len(get_indexes(db, ANNOTATIONS_COLLECTION)) == 0:
         create_index(db, ANNOTATIONS_COLLECTION)

--- a/gens/config.py
+++ b/gens/config.py
@@ -1,10 +1,26 @@
 """Gens default configuration."""
 
+import os
+from typing import Tuple, Type
 from enum import Enum
+from pathlib import Path
 
+from pydantic import BaseModel
 from pydantic import Field, HttpUrl, MongoDsn, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import (
+    BaseSettings, 
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 from pymongo.uri_parser import parse_uri
+
+# read default config and user defined config
+config_file = [Path(__file__).parent.joinpath('config.toml')]
+if os.getenv('CONFIG_FILE') is not None:
+    user_cnf = Path(os.getenv('CONFIG_FILE'))
+    if user_cnf.exists():
+        config_file.append(user_cnf)
 
 
 class AuthMethod(Enum):
@@ -13,6 +29,19 @@ class AuthMethod(Enum):
     OAUTH = "oauth"
     SIMPLE = "simple"
     DISABLED = "disabled"
+
+
+class OauthConfig(BaseSettings):
+    """Valid authentication options"""
+
+    client_id: str
+    secret: str
+    discovery_url: HttpUrl
+
+
+class MongoDbConfig(BaseSettings):
+    connection: MongoDsn = Field(..., description="Database connection string.")
+    database: str
 
 
 class Settings(BaseSettings):
@@ -24,15 +53,8 @@ class Settings(BaseSettings):
     )
 
     # For scout integration
-    scout_db: MongoDsn = Field(
-        MongoDsn("mongodb://mongodb:27017/scout"),
-        description="Connection to Gens mongo database.",
-    )
-    scout_url: HttpUrl = Field(
-        HttpUrl("http://localhost:8000"), description="Base URL to Scout."
-    )
-    gens_dbname: str = "gens"
-    scout_dbname: str = "scout"
+    scout_db: MongoDbConfig
+    scout_url: HttpUrl = Field(..., description="Base URL to Scout.")
 
     # Annotation
     default_annotation_track: str | None = None
@@ -41,20 +63,19 @@ class Settings(BaseSettings):
     authentication: AuthMethod = AuthMethod.DISABLED
 
     # Oauth options
-    oauth_client_id: str | None = None
-    oauth_secret: str | None = None
-    oauth_discovery_url: HttpUrl | None = None
+    oauth: OauthConfig | None = None
+
+    model_config = SettingsConfigDict(
+        env_file_encoding='utf-8', 
+        toml_file=config_file,
+        env_nested_delimiter="__",
+    )
 
     @model_validator(mode="after")
     def check_oauth_opts(self):
         """Check that OAUTH options are set if authentication is oauth."""
         if self.authentication == AuthMethod.OAUTH:
-            checks = [
-                self.oauth_client_id is not None,
-                self.oauth_secret is not None,
-                self.oauth_discovery_url is not None,
-            ]
-            if not all(checks):
+            if self.oauth is not None:
                 raise ValueError(
                     "OAUTH require you to configure client_id, secret and discovery_url"
                 )
@@ -68,20 +89,32 @@ class Settings(BaseSettings):
         DB name in connection string takes presidence over the variable <sw>_dbname.
         """
         # gens
-        conn_info = parse_uri(str(self.gens_db))
-        self.gens_dbname = (
-            self.gens_dbname if conn_info["database"] is None else conn_info["database"]
+        conn_info = parse_uri(str(self.gens_db.connection))
+        self.gens_db.database = (
+            self.gens_db.database if conn_info["database"] is None else conn_info["database"]
         )
 
         # scout
-        conn_info = parse_uri(str(self.scout_db))
-        self.scout_dbname = (
-            self.scout_dbname
+        conn_info = parse_uri(str(self.scout_db.connection))
+        self.scout_db.database = (
+            self.scout_db.database
             if conn_info["database"] is None
             else conn_info["database"]
         )
 
         return self
+    
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        toml_settings = TomlConfigSettingsSource(settings_cls)
+        return init_settings, env_settings, dotenv_settings, file_secret_settings, toml_settings
 
 
 UI_COLORS = {

--- a/gens/config.toml
+++ b/gens/config.toml
@@ -1,0 +1,8 @@
+scout_url = "http://localhost:8000"
+authentication = "simple"
+
+[gens_db]
+connection = "mongodb://mongodb:27017/gens"
+
+[scout_db]
+connection = "mongodb://mongodb:27017/scout"

--- a/gens/db/db.py
+++ b/gens/db/db.py
@@ -19,10 +19,10 @@ def init_database_connection() -> None:
     LOG.info("Initialize db connection")
 
     # connect to database
-    app.config["SCOUT_DB"] = MongoClient(str(settings.scout_db)).get_database(
+    app.config["SCOUT_DB"] = pymongo.MongoClient(str(settings.scout_db)).get_database(
         name=settings.scout_db.database
     )
-    app.config["GENS_DB"] = MongoClient(str(settings.gens_db)).get_database(
+    app.config["GENS_DB"] = pymongo.MongoClient(str(settings.gens_db)).get_database(
         name=settings.gens_db.database
     )
 

--- a/gens/db/db.py
+++ b/gens/db/db.py
@@ -19,11 +19,11 @@ def init_database_connection() -> None:
     LOG.info("Initialize db connection")
 
     # connect to database
-    app.config["SCOUT_DB"] = pymongo.MongoClient(str(settings.scout_db)).get_database(
-        name=settings.scout_dbname
+    app.config["SCOUT_DB"] = MongoClient(str(settings.scout_db)).get_database(
+        name=settings.scout_db.database
     )
-    app.config["GENS_DB"] = pymongo.MongoClient(str(settings.gens_db)).get_database(
-        name=settings.gens_dbname
+    app.config["GENS_DB"] = MongoClient(str(settings.gens_db)).get_database(
+        name=settings.gens_db.database
     )
 
 


### PR DESCRIPTION
This PR adds the option to configure Gens using a custom toml file that can be mounted to the container. The path to the config is specified using the `CONFIG_FILE` environment variable and should be a path inside the container and point to a location where the `worker` user have read permission.

Configs have the following priority order
1. Env variables
2. Dotfile
3. Custom toml
4. Default configuration (found in `config.toml`)

**How to test**:

Example of using a custom config toml. Add the following to the `docker-compose.dev.yml`

```yaml
services:
  gens:
    environment:
      - CONFIG_FILE=/home/worker/user.conf.toml
    volumes:
      - ./user.conf.toml:/home/worker/user.conf.toml
```

The custom toml

```toml
[oauth]
discovery_url = "http://www.oauth.toml.com"
```

For test simplicity add this at the bottom of `config.py`
`raise ValueError(settings)`

**Expected outcome**

1. Without specifying the custom toml, `oauth=None`
2. With `user.conf.toml` => `oauth="http://www.oauth.toml.com"`
3. Add `OAUTH__DISCOVERY_URL=http://www.oauth.env.com` to docker compose file and update containers. `oauth="http://www.oauth.env.com"`


**Review:**
- [ ] code approved by
