### PR TITLE
Annotations fixes

### DIFF
--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -1,4 +1,4 @@
-import Choices, { InputChoice } from "choices.js";
+import Choices, { EventChoice, InputChoice } from "choices.js";
 import {
   getPan,
   parseRegionDesignation,
@@ -77,8 +77,15 @@ export class InputControls extends HTMLElement {
     return this.region;
   }
 
-  getAnnotSources(): string[] {
-    return this.annotationSelectChoices.getValue(true) as string[];
+  getAnnotSources(): {id: string, label: string}[] {
+    const selectedObjs = this.annotationSelectChoices.getValue() as EventChoice[];
+    const returnVals = selectedObjs.map((obj) => {
+      return {
+        id: obj.value,
+        label: obj.label.toString()
+      }
+    })
+    return returnVals;
   }
 
   getRange(): [number, number] {

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -77,14 +77,15 @@ export class InputControls extends HTMLElement {
     return this.region;
   }
 
-  getAnnotSources(): {id: string, label: string}[] {
-    const selectedObjs = this.annotationSelectChoices.getValue() as EventChoice[];
+  getAnnotSources(): { id: string; label: string }[] {
+    const selectedObjs =
+      this.annotationSelectChoices.getValue() as EventChoice[];
     const returnVals = selectedObjs.map((obj) => {
       return {
         id: obj.value,
-        label: obj.label.toString()
-      }
-    })
+        label: obj.label.toString(),
+      };
+    });
     return returnVals;
   }
 

--- a/assets/js/components/tracks/annotation_tracks.ts
+++ b/assets/js/components/tracks/annotation_tracks.ts
@@ -1,4 +1,3 @@
-import { AnnotationTrack } from "../../unused/track/_annotation";
 import { removeChildren } from "../../util/utils";
 import { ShadowBaseElement as ShadowBaseElement } from "../util/shadowbase";
 import { BandTrack } from "./band_track";

--- a/assets/js/components/tracks/multi_track.ts
+++ b/assets/js/components/tracks/multi_track.ts
@@ -100,4 +100,4 @@ function checkTracksDiffer(
   return addedSources.length != 0 || removedSources.length != 0;
 }
 
-customElements.define("annotation-tracks", MultiTracks);
+customElements.define("multi-tracks", MultiTracks);

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -3,9 +3,9 @@ import "./tracks/band_track";
 import "./tracks/dot_track";
 import "./tracks/ideogram_track";
 import "./tracks/overview_track";
-import "./tracks/annotation_tracks";
+import "./tracks/multi_track";
 import { IdeogramTrack } from "./tracks/ideogram_track";
-import { AnnotationTracks } from "./tracks/annotation_tracks";
+import { MultiTracks } from "./tracks/multi_track";
 import { OverviewTrack } from "./tracks/overview_track";
 import { DotTrack } from "./tracks/dot_track";
 import { BandTrack } from "./tracks/band_track";
@@ -47,7 +47,7 @@ export class TracksManager extends HTMLElement {
   annotationsContainer: HTMLDivElement;
 
   // FIXME: Think about a shared interface
-  tracks: (CanvasTrack | AnnotationTracks)[] = [];
+  tracks: (CanvasTrack | MultiTracks)[] = [];
 
   // This one needs a dedicated component I think
   annotationTracks: BandTrack[] = [];
@@ -71,7 +71,7 @@ export class TracksManager extends HTMLElement {
     dataSource: RenderDataSource,
     getChromosome: () => string,
     getXRange: () => Rng,
-    getAnnotSources: () => string[],
+    getAnnotSources: () => { id: string, label: string }[],
     getVariantURL: (id: string) => string,
   ) {
     const trackHeight = STYLE.bandTrack.trackHeight;
@@ -154,11 +154,12 @@ export class TracksManager extends HTMLElement {
 
     );
 
-    const annotationTracks = new AnnotationTracks(
+    const annotationTracks = new MultiTracks(
       getAnnotSources,
-      (source: string) => {
+      (sourceId: string, label: string) => {
         return getAnnotTrack(
-          source,
+          sourceId,
+          label,
           trackHeight.thin,
           getXRange,
           dataSource.getAnnotation,
@@ -228,10 +229,11 @@ export class TracksManager extends HTMLElement {
 }
 
 function getAnnotTrack(
-  source: string,
+  sourceId: string,
+  label: string,
   trackHeight: number,
   getXRange: () => Rng,
-  getAnnotation: (source: string) => Promise<RenderBand[]>,
+  getAnnotation: (sourceId: string) => Promise<RenderBand[]>,
 ): BandTrack {
   const getPopupInfo = (box) => {
     const element = box.element as RenderBand;
@@ -245,9 +247,9 @@ function getAnnotTrack(
   };
 
   const track = new BandTrack(
-    source,
+    label,
     trackHeight,
-    () => getAnnotTrackData(source, getXRange, getAnnotation),
+    () => getAnnotTrackData(sourceId, getXRange, getAnnotation),
     getPopupInfo,
   );
   return track;

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -39,11 +39,10 @@ export class API {
       }
 
       const query = {};
-      const annotsResult = await get(
+      const annotations = await get(
         new URL(`tracks/annotations/${trackId}`, this.apiURI).href,
         query,
-      );
-      const annotations = annotsResult.annotations as ApiSimplifiedAnnotation[];
+      ) as ApiSimplifiedAnnotation[];
 
       this.annotCache[trackId] = annotations;
     }

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -30,19 +30,26 @@ export class API {
     return annotSources;
   }
 
-  private annotsPerChromCache: Record<string, Record<string, ApiSimplifiedAnnotation[]>> = {};
-  async getAnnotations(trackId: string, chrom: string): Promise<ApiSimplifiedAnnotation[]> {
-    const isCached = this.annotsPerChromCache[chrom] && this.annotsPerChromCache[trackId];
+  private annotsPerChromCache: Record<
+    string,
+    Record<string, ApiSimplifiedAnnotation[]>
+  > = {};
+  async getAnnotations(
+    trackId: string,
+    chrom: string,
+  ): Promise<ApiSimplifiedAnnotation[]> {
+    const isCached =
+      this.annotsPerChromCache[chrom] && this.annotsPerChromCache[trackId];
     if (!isCached) {
       if (this.annotsPerChromCache[trackId] === undefined) {
         this.annotsPerChromCache[trackId] = {};
       }
 
       const query = {};
-      const annotations = await get(
+      const annotations = (await get(
         new URL(`tracks/annotations/${trackId}`, this.apiURI).href,
         query,
-      ) as ApiSimplifiedAnnotation[];
+      )) as ApiSimplifiedAnnotation[];
 
       const annotsPerChrom: Record<string, ApiSimplifiedAnnotation[]> = {};
       annotations.forEach((annot) => {
@@ -50,7 +57,7 @@ export class API {
           annotsPerChrom[annot.chrom] = [];
         }
         annotsPerChrom[annot.chrom].push(annot);
-      })
+      });
 
       this.annotsPerChromCache[trackId] = annotsPerChrom;
     }

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -30,12 +30,12 @@ export class API {
     return annotSources;
   }
 
-  private annotCache: Record<string, ApiSimplifiedAnnotation[]> = {};
-  async getAnnotations(trackId: string): Promise<ApiSimplifiedAnnotation[]> {
-    const isCached = this.annotCache[trackId];
+  private annotsPerChromCache: Record<string, Record<string, ApiSimplifiedAnnotation[]>> = {};
+  async getAnnotations(trackId: string, chrom: string): Promise<ApiSimplifiedAnnotation[]> {
+    const isCached = this.annotsPerChromCache[chrom] && this.annotsPerChromCache[trackId];
     if (!isCached) {
-      if (this.annotCache[trackId] === undefined) {
-        this.annotCache[trackId] = [];
+      if (this.annotsPerChromCache[trackId] === undefined) {
+        this.annotsPerChromCache[trackId] = {};
       }
 
       const query = {};
@@ -44,9 +44,17 @@ export class API {
         query,
       ) as ApiSimplifiedAnnotation[];
 
-      this.annotCache[trackId] = annotations;
+      const annotsPerChrom: Record<string, ApiSimplifiedAnnotation[]> = {};
+      annotations.forEach((annot) => {
+        if (annotsPerChrom[annot.chrom] === undefined) {
+          annotsPerChrom[annot.chrom] = [];
+        }
+        annotsPerChrom[annot.chrom].push(annot);
+      })
+
+      this.annotsPerChromCache[trackId] = annotsPerChrom;
     }
-    return this.annotCache[trackId];
+    return this.annotsPerChromCache[trackId][chrom];
   }
 
   private covCache: Record<string, ApiCoverageDot[]> = {};

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -68,10 +68,13 @@ export function getRenderDataSource(
   
 
 export function parseAnnotations(annotations: ApiSimplifiedAnnotation[]): RenderBand[] {
+
+  console.log(annotations);
+
   const results = annotations.map((annot) => {
     // const rankScore = annot.score ? `, Rankscore: ${annot.score}` : "";
     const label = annot.name;
-    const colorStr = rgbArrayToString(annot.color);
+    const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
     return {
       id: `${annot.start}_${annot.end}_${colorStr}`,
       start: annot.start,

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -12,7 +12,7 @@ export function getRenderDataSource(
     };
   
     const getAnnotation = async (recordId: string) => {
-      const annotData = await gensAPI.getAnnotations(recordId);
+      const annotData = await gensAPI.getAnnotations(recordId, getChrom());
       return parseAnnotations(annotData);
     };
   
@@ -69,17 +69,14 @@ export function getRenderDataSource(
 
 export function parseAnnotations(annotations: ApiSimplifiedAnnotation[]): RenderBand[] {
 
-  console.log(annotations);
-
   const results = annotations.map((annot) => {
-    // const rankScore = annot.score ? `, Rankscore: ${annot.score}` : "";
     const label = annot.name;
-    const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
+    // const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
     return {
-      id: `${annot.start}_${annot.end}_${colorStr}`,
+      id: `${annot.start}_${annot.end}_${annot.color}_${label}`,
       start: annot.start,
       end: annot.end,
-      color: colorStr,
+      color: annot.color,
       label,
       hoverInfo: `${annot.name} (${annot.start}-${annot.end})`,
     };
@@ -87,13 +84,10 @@ export function parseAnnotations(annotations: ApiSimplifiedAnnotation[]): Render
   return results;
 }
 
-// FIXME: Should this one be here?
 function parseExons(
   geneId: string,
   exons: {start: number, end: number}[],
 ): RenderBand[] {
-  // const exons = transcriptParts.filter((part) => part.feature == "exon");
-
   return exons.map((part, i) => {
     const renderBand = {
       id: `${geneId}_exon${i + 1}_${part.start}_${part.end}`,

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -4,71 +4,71 @@ import { transformMap } from "../util/utils";
 import { API } from "./api";
 
 export function getRenderDataSource(
-    gensAPI: API,
-    getChrom: () => string,
-  ): RenderDataSource {
-    const getChromInfo = async () => {
-      return await gensAPI.getChromData(getChrom());
-    };
-  
-    const getAnnotation = async (recordId: string) => {
-      const annotData = await gensAPI.getAnnotations(recordId, getChrom());
-      return parseAnnotations(annotData);
-    };
-  
-    const getCovData = async () => {
-      const covRaw = await gensAPI.getCov(getChrom());
-      return parseCoverageDot(covRaw, STYLE.colors.teal);
-    };
-  
-    const getBafData = async () => {
-      const bafRaw = await gensAPI.getBaf(getChrom());
-      return parseCoverageDot(bafRaw, STYLE.colors.orange);
-    };
-  
-    const getTranscriptData = async () => {
-      const onlyMane = true;
-      const transcriptsRaw = await gensAPI.getTranscripts(getChrom(), onlyMane);
-      return parseTranscripts(transcriptsRaw);
-    };
-  
-    const getVariantData = async () => {
-      const variantsRaw = await gensAPI.getVariants(getChrom());
-      return parseVariants(variantsRaw, STYLE.variantColors);
-    };
-  
-    const getOverviewCovData = async () => {
-      const overviewCovRaw = await gensAPI.getOverviewCovData();
-      const overviewCovRender = transformMap(overviewCovRaw, (cov) =>
-        parseCoverageDot(cov, STYLE.colors.darkGray),
-      );
-      return overviewCovRender;
-    };
-  
-    const getOverviewBafData = async () => {
-      const overviewBafRaw = await gensAPI.getOverviewBafData();
-      const overviewBafRender = transformMap(overviewBafRaw, (cov) =>
-        parseCoverageDot(cov, STYLE.colors.darkGray),
-      );
-      return overviewBafRender;
-    };
-  
-    const renderDataSource: RenderDataSource = {
-      getChromInfo,
-      getAnnotation,
-      getCovData,
-      getBafData,
-      getTranscriptData,
-      getVariantData,
-      getOverviewCovData,
-      getOverviewBafData,
-    };
-    return renderDataSource;
-  }
-  
+  gensAPI: API,
+  getChrom: () => string,
+): RenderDataSource {
+  const getChromInfo = async () => {
+    return await gensAPI.getChromData(getChrom());
+  };
 
-export function parseAnnotations(annotations: ApiSimplifiedAnnotation[]): RenderBand[] {
+  const getAnnotation = async (recordId: string) => {
+    const annotData = await gensAPI.getAnnotations(recordId, getChrom());
+    return parseAnnotations(annotData);
+  };
 
+  const getCovData = async () => {
+    const covRaw = await gensAPI.getCov(getChrom());
+    return parseCoverageDot(covRaw, STYLE.colors.teal);
+  };
+
+  const getBafData = async () => {
+    const bafRaw = await gensAPI.getBaf(getChrom());
+    return parseCoverageDot(bafRaw, STYLE.colors.orange);
+  };
+
+  const getTranscriptData = async () => {
+    const onlyMane = true;
+    const transcriptsRaw = await gensAPI.getTranscripts(getChrom(), onlyMane);
+    return parseTranscripts(transcriptsRaw);
+  };
+
+  const getVariantData = async () => {
+    const variantsRaw = await gensAPI.getVariants(getChrom());
+    return parseVariants(variantsRaw, STYLE.variantColors);
+  };
+
+  const getOverviewCovData = async () => {
+    const overviewCovRaw = await gensAPI.getOverviewCovData();
+    const overviewCovRender = transformMap(overviewCovRaw, (cov) =>
+      parseCoverageDot(cov, STYLE.colors.darkGray),
+    );
+    return overviewCovRender;
+  };
+
+  const getOverviewBafData = async () => {
+    const overviewBafRaw = await gensAPI.getOverviewBafData();
+    const overviewBafRender = transformMap(overviewBafRaw, (cov) =>
+      parseCoverageDot(cov, STYLE.colors.darkGray),
+    );
+    return overviewBafRender;
+  };
+
+  const renderDataSource: RenderDataSource = {
+    getChromInfo,
+    getAnnotation,
+    getCovData,
+    getBafData,
+    getTranscriptData,
+    getVariantData,
+    getOverviewCovData,
+    getOverviewBafData,
+  };
+  return renderDataSource;
+}
+
+export function parseAnnotations(
+  annotations: ApiSimplifiedAnnotation[],
+): RenderBand[] {
   const results = annotations.map((annot) => {
     const label = annot.name;
     // const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
@@ -86,7 +86,7 @@ export function parseAnnotations(annotations: ApiSimplifiedAnnotation[]): Render
 
 function parseExons(
   geneId: string,
-  exons: {start: number, end: number}[],
+  exons: { start: number; end: number }[],
 ): RenderBand[] {
   return exons.map((part, i) => {
     const renderBand = {
@@ -100,7 +100,9 @@ function parseExons(
   });
 }
 
-export function parseTranscripts(transcripts: ApiSimplifiedTranscript[]): RenderBand[] {
+export function parseTranscripts(
+  transcripts: ApiSimplifiedTranscript[],
+): RenderBand[] {
   const transcriptsToRender: RenderBand[] = transcripts.map((transcript) => {
     const exons = parseExons(transcript.record_id, transcript.features);
     const renderBand: RenderBand = {
@@ -119,7 +121,7 @@ export function parseTranscripts(transcripts: ApiSimplifiedTranscript[]): Render
   // FIXME: This should be done on the backend
   const seenIds = new Set();
   const filteredDuplicates = transcriptsToRender.filter((tr) => {
-    const fingerprint = `${tr.label}_${tr.start}_${tr.end}`
+    const fingerprint = `${tr.label}_${tr.start}_${tr.end}`;
     if (seenIds.has(fingerprint)) {
       return false;
     } else {

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -13,7 +13,8 @@ interface ApiSimplifiedAnnotation {
   type: string,
   start: number,
   end: number,
-  color: number[] | null
+  chrom: string,
+  color: string | null
 }
 
 interface ApiSimplifiedTranscript {

--- a/gens/crud/annotations.py
+++ b/gens/crud/annotations.py
@@ -104,7 +104,7 @@ def get_annotations_for_track(
     track_id: PydanticObjectId, db: Database[Any]
 ) -> list[SimplifiedTrackInfo]:
     """Get annotation track from database."""
-    projection: dict[str, bool] = {"name": True, "start": True, "end": True}
+    projection: dict[str, bool] = {"name": True, "start": True, "end": True, "chrom": True, "color": True}
     cursor: Any = db.get_collection(ANNOTATIONS_COLLECTION).find(
         {"track_id": track_id}, projection
     )
@@ -113,8 +113,10 @@ def get_annotations_for_track(
             {
                 "record_id": doc["_id"],
                 "name": doc["name"],
+                "chrom": doc["chrom"],
                 "start": doc["start"],
                 "end": doc["end"],
+                "color": doc["color"],
                 "type": "annotation",
             }
         )

--- a/gens/crud/samples.py
+++ b/gens/crud/samples.py
@@ -83,7 +83,8 @@ def get_samples(
     # cast as sample object
     result = MultipleSamples(
         data=[SampleInfo.model_validate(sample) for sample in cursor],
-        recordsTotal=samples_c.count_documents({}),
+        # mypy cannot deal with the pydantic alias records_total -> recordsTotal, thus the ignore
+        recordsTotal=samples_c.count_documents({}),  # type: ignore
     )
     return result
 

--- a/gens/load/annotations.py
+++ b/gens/load/annotations.py
@@ -427,13 +427,12 @@ def fmt_aed_to_annotation(
             )
         else:
 
-            if not value:
-                raise ValueError(f"Unexpected point for value: {value}")
+            metadata.append(
+                GenericMetadata(field_name=field_name, value=str(value), type="string")
+            )
 
-            # metadata.append(
-            #     GenericMetadata(field_name=field_name, value=str(value), type="string")
-            # )
-
+    # Various checks to make sure the received data is in expected format
+    # This data is manually entered, meaning that various types of errors might and will be found here
     try:
         rec_start = record["start"]
     except KeyError:
@@ -441,9 +440,6 @@ def fmt_aed_to_annotation(
     rec_end = record["end"]
     rec_color = record["color"]
     rec_sequence = record["sequence"]
-
-    # if not rec_name or not isinstance(rec_name, str):
-    #     raise ValueError(f"name expected in string format, found: {rec_name} for record {record}")
 
     if rec_start is None or not isinstance(rec_start, int) or rec_start <= 0:
         raise ValueError(f"start expected to be present and greater than 0, found: {rec_start} for record {record}")
@@ -454,7 +450,6 @@ def fmt_aed_to_annotation(
     if not rec_color or not isinstance(rec_color, Color):
         LOG.error(f"Unknown color: {rec_color}, assigning black")
         rec_color = Color("#000000")
-        # raise ValueError(f"color expected in Color format, found: {rec_color} for record {record}")
 
     if rec_sequence is None or not isinstance(rec_sequence, str):
         raise ValueError(f"sequence expected in str format, found: {rec_sequence}")

--- a/gens/load/annotations.py
+++ b/gens/load/annotations.py
@@ -217,7 +217,7 @@ def format_aed_entry(value: str, format: str) -> AedDatatypes:
         case _ if format.startswith("aed:"):
             return value
         case _:
-            LOG.warning(f"Unknown format: {format}, returning as is")
+            LOG.warning(f"Unknown format: {format}, returning value as is ({value})")
             return value
 
 

--- a/gens/models/annotation.py
+++ b/gens/models/annotation.py
@@ -139,6 +139,7 @@ class SimplifiedTrackInfo(GenomePosition, RWModel):
     name: str
     type: str  # snv / mane
     color: Color | None = None
+    chrom: str | None = None
 
 
 class SimplifiedTranscriptInfo(SimplifiedTrackInfo):

--- a/gens/models/genomic.py
+++ b/gens/models/genomic.py
@@ -110,7 +110,7 @@ class GenomicRegion(RWModel):
     start: int | None
     end: int | None
 
-    @computed_field
+    @computed_field()  # type: ignore
     @property
     def region(self) -> str:
         return f"{self.chromosome}:{self.start}-{self.end}"

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -38,7 +38,7 @@ async def get_annotations_tracks(genome_build: GenomeBuild | None, db: GensDb) -
 async def get_annotation_track(
     track_id: PydanticObjectId, db: GensDb
 ) -> list[SimplifiedTrackInfo]:
-    """Get annoations for a region."""
+    """Get annotations for a region."""
     return get_annotations_for_track(track_id=track_id, db=db)
 
 
@@ -46,7 +46,7 @@ async def get_annotation_track(
 async def get_annotation_with_id(
     record_id: PydanticObjectId, db: GensDb
 ) -> AnnotationRecord:
-    """Get annoations for a region."""
+    """Get annotations for a region."""
     result = get_annotation(record_id, db)
     if result is None:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND)


### PR DESCRIPTION
Brings back annotations to the front end after various back-end changes.

* Various parsing fixes to allow non-perfect formatting of aed files (these files contain manual inputs and can have many different shapes and looks). We might want to consider keeping the even more permissive approach from before - just skipping entries that are not correct while emitting a warning.
* Chromosome included in annotations returned to front end.
* UI considers that the select now distinguishes track IDs and labels.