### PR TITLE
Get running on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
  - Tracks expand with wider window size.
+ - Tracks retrieve data on demand and caches requests.
+ - Multiple annotation tracks.
+ - Popup context menu when clicking band tracks.
 
 ### Changed
  - Resolution increased 2x for tracks.

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -66,8 +66,8 @@ export class TracksManager extends HTMLElement {
   }
 
   async initialize(
-    getChromInfo: (string) => ChromosomeInfo,
-    chromClick: (string) => void,
+    chromSizes: Record<string, number>,
+    chromClick: (chrom: string) => void,
     dataSource: RenderDataSource,
     getChromosome: () => string,
     getXRange: () => Rng,
@@ -178,10 +178,6 @@ export class TracksManager extends HTMLElement {
       },
     );
 
-    const chromSizes = {};
-    for (const chromosome of CHROMOSOMES) {
-      chromSizes[chromosome] = getChromInfo(chromosome).size;
-    }
 
     const overviewTrackCov = new OverviewTrack(
       "overview_cov",

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -23,7 +23,7 @@ export class API {
 
   async getAnnotationSources(): Promise<ApiAnnotationTrack[]> {
     const annotSources = (await get(
-      new URL("/tracks/annotations", this.apiURI).href,
+      new URL("tracks/annotations", this.apiURI).href,
       {
         genome_build: this.genomeBuild,
       },
@@ -151,7 +151,7 @@ export class API {
         genome_build: 38,
       };
       const transcripts = (await get(
-        new URL("/tracks/transcripts", this.apiURI).href,
+        new URL("tracks/transcripts", this.apiURI).href,
         query,
       )) as ApiSimplifiedTranscript[];
 

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -129,12 +129,14 @@ export class API {
   private transcriptCache: Record<string, Promise<ApiSimplifiedTranscript[]>> = {};
   getTranscripts(
     chrom: string,
+    onlyMane: boolean
   ): Promise<ApiSimplifiedTranscript[]> {
     const isCached = this.transcriptCache[chrom] !== undefined;
     if (!isCached) {
       const query = {
         chromosome: chrom,
         genome_build: 38,
+        only_mane: onlyMane
       };
       const transcripts = (get(
         new URL("tracks/transcripts", this.apiURI).href,

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -143,13 +143,7 @@ export class API {
         query,
       )) as Promise<ApiSimplifiedTranscript[]>;
 
-      // if (maneOnly) {
-      //   this.transcriptCache[chrom] = transcripts.filter(
-      //     (tr) => tr.type == "MANE Select",
-      //   );
-      // } else {
       this.transcriptCache[chrom] = transcripts;
-      // }
     }
     return this.transcriptCache[chrom];
   }
@@ -188,24 +182,6 @@ export class API {
     return this.chromCache[chrom];
   }
 
-  // // FIXME: This would be better as a single request I think
-  // async getAllChromData(): Promise<Record<string, ChromosomeInfo>> {
-  //   await Promise.all(
-  //     CHROMOSOMES.map(async (chrom) => {
-  //       if (this.chromCache[chrom] === undefined) {
-  //         const chromosomeInfo = (await get(
-  //           new URL(`tracks/chromosomes/${chrom}`, this.apiURI).href,
-  //           {
-  //             genome_build: this.genomeBuild,
-  //           },
-  //         )) as ChromosomeInfo;
-
-  //         this.chromCache[chrom] = chromosomeInfo;
-  //       }
-  //     }),
-  //   );
-  //   return this.chromCache;
-  // }
 
   private overviewCovCache: Promise<Record<string, ApiCoverageDot[]>> = null;
   getOverviewCovData(): Promise<Record<string, ApiCoverageDot[]>> {

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -52,7 +52,7 @@ export function getRenderDataSource(
   const getTranscriptData = async () => {
     const onlyMane = true;
     const transcriptsRaw = await gensAPI.getTranscripts(getChrom(), onlyMane);
-    return parseTranscripts(transcriptsRaw, false);
+    return parseTranscripts(transcriptsRaw);
   };
 
   const getVariantData = async () => {
@@ -97,7 +97,6 @@ export function parseAnnotations(
     .filter((annot) => (annot.chrom == chromosome))
     .map((annot) => {
       const label = annot.name;
-      // const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
       return {
         id: `${annot.start}_${annot.end}_${annot.color}_${label}`,
         start: annot.start,
@@ -128,10 +127,8 @@ function parseExons(
 
 export function parseTranscripts(
   transcripts: ApiSimplifiedTranscript[],
-  onlyMane: boolean
 ): RenderBand[] {
   const transcriptsToRender: RenderBand[] = transcripts
-    .filter((tr) => onlyMane ? tr.type == "MANE Select" : true)
     .map((transcript) => {
       const exons = parseExons(transcript.record_id, transcript.features);
       const renderBand: RenderBand = {

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -50,9 +50,9 @@ export function getRenderDataSource(
   };
 
   const getTranscriptData = async () => {
-    const transcriptsRaw = await gensAPI.getTranscripts(getChrom());
     const onlyMane = true;
-    return parseTranscripts(transcriptsRaw, onlyMane);
+    const transcriptsRaw = await gensAPI.getTranscripts(getChrom(), onlyMane);
+    return parseTranscripts(transcriptsRaw, false);
   };
 
   const getVariantData = async () => {

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -2,7 +2,7 @@ import { STYLE } from "../constants";
 import { transformMap } from "../util/utils";
 import { API } from "./api";
 
-function calculateZoom (xRange: Rng) {
+function calculateZoom(xRange: Rng) {
   const xRangeSize = xRange[1] - xRange[0];
   let returnVal;
   if (xRangeSize > 100 * 10 ** 6) {
@@ -11,13 +11,13 @@ function calculateZoom (xRange: Rng) {
     returnVal = "a";
   } else if (xRangeSize > 10 * 10 ** 6) {
     returnVal = "b";
-  } else if (xRangeSize > 500 * 10 ** 3 ) {
+  } else if (xRangeSize > 500 * 10 ** 3) {
     returnVal = "c";
   } else {
     returnVal = "d";
   }
   return returnVal;
-};
+}
 
 export function getRenderDataSource(
   gensAPI: API,
@@ -29,12 +29,11 @@ export function getRenderDataSource(
   };
 
   const getAnnotation = async (recordId: string) => {
-    const annotData = await gensAPI.getAnnotations(recordId, getChrom());
-    return parseAnnotations(annotData);
+    const annotData = await gensAPI.getAnnotations(recordId);
+    return parseAnnotations(annotData, getChrom());
   };
 
   const getCovData = async () => {
-
     const xRange = getXRange();
     const zoom = calculateZoom(xRange);
 
@@ -43,7 +42,6 @@ export function getRenderDataSource(
   };
 
   const getBafData = async () => {
-
     const xRange = getXRange();
     const zoom = calculateZoom(xRange);
 
@@ -52,9 +50,9 @@ export function getRenderDataSource(
   };
 
   const getTranscriptData = async () => {
+    const transcriptsRaw = await gensAPI.getTranscripts(getChrom());
     const onlyMane = true;
-    const transcriptsRaw = await gensAPI.getTranscripts(getChrom(), onlyMane);
-    return parseTranscripts(transcriptsRaw);
+    return parseTranscripts(transcriptsRaw, onlyMane);
   };
 
   const getVariantData = async () => {
@@ -93,19 +91,22 @@ export function getRenderDataSource(
 
 export function parseAnnotations(
   annotations: ApiSimplifiedAnnotation[],
+  chromosome: string,
 ): RenderBand[] {
-  const results = annotations.map((annot) => {
-    const label = annot.name;
-    // const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
-    return {
-      id: `${annot.start}_${annot.end}_${annot.color}_${label}`,
-      start: annot.start,
-      end: annot.end,
-      color: annot.color,
-      label,
-      hoverInfo: `${annot.name} (${annot.start}-${annot.end})`,
-    };
-  });
+  const results = annotations
+    .filter((annot) => (annot.chrom == chromosome))
+    .map((annot) => {
+      const label = annot.name;
+      // const colorStr = annot.color != null ? rgbArrayToString(annot.color) : "black";
+      return {
+        id: `${annot.start}_${annot.end}_${annot.color}_${label}`,
+        start: annot.start,
+        end: annot.end,
+        color: annot.color,
+        label,
+        hoverInfo: `${annot.name} (${annot.start}-${annot.end})`,
+      };
+    });
   return results;
 }
 
@@ -127,21 +128,24 @@ function parseExons(
 
 export function parseTranscripts(
   transcripts: ApiSimplifiedTranscript[],
+  onlyMane: boolean
 ): RenderBand[] {
-  const transcriptsToRender: RenderBand[] = transcripts.map((transcript) => {
-    const exons = parseExons(transcript.record_id, transcript.features);
-    const renderBand: RenderBand = {
-      id: transcript.record_id,
-      start: transcript.start,
-      end: transcript.end,
-      label: transcript.name,
-      color: STYLE.colors.lightGray,
-      hoverInfo: `${transcript.name} (${transcript.record_id})`,
-      direction: transcript.strand as "+" | "-",
-      subBands: exons,
-    };
-    return renderBand;
-  });
+  const transcriptsToRender: RenderBand[] = transcripts
+    .filter((tr) => onlyMane ? tr.type == "MANE Select" : true)
+    .map((transcript) => {
+      const exons = parseExons(transcript.record_id, transcript.features);
+      const renderBand: RenderBand = {
+        id: transcript.record_id,
+        start: transcript.start,
+        end: transcript.end,
+        label: transcript.name,
+        color: STYLE.colors.lightGray,
+        hoverInfo: `${transcript.name} (${transcript.record_id})`,
+        direction: transcript.strand as "+" | "-",
+        subBands: exons,
+      };
+      return renderBand;
+    });
 
   // FIXME: This should be done on the backend
   const seenIds = new Set();

--- a/gens/auth.py
+++ b/gens/auth.py
@@ -13,7 +13,7 @@ oauth_client = OAuth()
 
 
 class LoginUser(UserMixin):
-    """User object that controlls user roles and credentials."""
+    """User object that controls user roles and credentials."""
 
     def __init__(self, user_obj: User):
         """Create a new user object."""

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -107,7 +107,7 @@
             end: endJs,
         },
         // FIXME: This should come from the backend
-        gensApiURL: "http://localhost:8080/"
+        gensApiURL: '{{ gens_api_url }}'
     })
     // draw statis content
     const visualizationContainer = document.getElementById('visualization-container')

--- a/gens/blueprints/gens/views.py
+++ b/gens/blueprints/gens/views.py
@@ -14,6 +14,8 @@ from gens.db.collections import SAMPLES_COLLECTION
 from gens.genomic import parse_region_str
 from gens.models.genomic import GenomeBuild
 
+from gens.config import settings
+
 LOG = logging.getLogger(__name__)
 
 gens_bp = Blueprint(
@@ -90,4 +92,5 @@ def display_case(sample_name: str) -> str:
         selected_variant=selected_variant,
         todays_date=date.today(),
         version=version,
+        gens_api_url=settings.gens_api_url
     )

--- a/gens/blueprints/login/views.py
+++ b/gens/blueprints/login/views.py
@@ -26,7 +26,7 @@ def load_user(user_id: str) -> LoginUser | None:
     # get database instance
     db: Database[Any] = current_app.config["GENS_DB"]
     user_col = db.get_collection(USER_COLLECTION)
-    user_obj = get_user(user_col, user_id)  # type: ignore
+    user_obj = get_user(user_col, user_id)
     if user_obj is not None:
         return LoginUser(user_obj)
     return None

--- a/gens/config.py
+++ b/gens/config.py
@@ -54,6 +54,7 @@ class Settings(BaseSettings):
     gens_db: MongoDbConfig
     scout_db: MongoDbConfig
     scout_url: HttpUrl = Field(..., description="Base URL to Scout.")
+    gens_api_url: HttpUrl = Field(..., description="Gens API URL")
 
     # Annotation
     default_annotation_track: str | None = None
@@ -75,6 +76,7 @@ class Settings(BaseSettings):
             "gens_db": self.gens_db.database,
             "scout_db": self.scout_db.database,
             "scout_url": self.scout_url,
+            "gens_api_url": self.gens_api_url,
             "default_annotation_track": self.default_annotation_track,
             "authentication": self.authentication.value,
             "oauth": self.oauth,

--- a/gens/config.toml
+++ b/gens/config.toml
@@ -1,5 +1,6 @@
 scout_url = "http://localhost:8000"
 authentication = "disabled"
+gens_api_url = "http://localhost:8080/"
 
 [gens_db]
 connection = "mongodb://mongodb:27017/gens"

--- a/gens/crud/user.py
+++ b/gens/crud/user.py
@@ -15,6 +15,8 @@ def get_user(user_c: Collection[Any], email: str) -> User | None:
     """
     query = {"email": email}
     user_info: dict[str, str] | None = user_c.find_one(query)
+    if user_info is None:
+        return None
     return User.model_validate(user_info)
 
 

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -71,7 +71,7 @@ async def get_transcripts(
     if end is None:
         chrom_info = get_chromosome_info(db, chromosome, genome_build)
         if chrom_info is None:
-            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"No information on chromoseom: {chromosome}")
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"No information on chromosome: {chromosome}")
         end = chrom_info.size
 
     region = GenomicRegion(chromosome=chromosome, start=start, end=end)

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -60,6 +60,7 @@ async def get_transcripts(
     db: GensDb,
     start: int | None = 1,
     end: int | None = None,
+    only_mane: bool = False,
 ) -> list[SimplifiedTranscriptInfo]:
     """Get all transcripts for a sample.
 
@@ -77,6 +78,8 @@ async def get_transcripts(
 
     # get transcript for the new region
     transcripts: list[SimplifiedTranscriptInfo] = crud_get_transcripts(region, genome_build, db)
+    if only_mane:
+        transcripts = [tr for tr in transcripts if tr.type == "MANE Select"]
     return transcripts
 
 


### PR DESCRIPTION
Various fixes and optimizations for running on server.

* Cache promises instead of actual data for API requests, to prevent repeated requests before the data request is completed.
* Gens API point in config file.
* Option to return MANE select only directly from API (to avoid transferring 30MB and then parsing out the needed 4MB client side).