### PR TITLE
Deploy annotations

### DIFF
--- a/assets/css/gens.scss
+++ b/assets/css/gens.scss
@@ -14,6 +14,10 @@ $header-background-blue: #bbcadc;
 $source-border-color: rgba(27, 31, 35, 0.15);
 $marker-gray-color: #7c7c7c;
 
+.choices__list--dropdown {
+  z-index: 3000;
+}
+
 .tooltip {
   background: $dark-gray-color;
   color: $white-color;

--- a/assets/css/gens.scss
+++ b/assets/css/gens.scss
@@ -14,10 +14,6 @@ $header-background-blue: #bbcadc;
 $source-border-color: rgba(27, 31, 35, 0.15);
 $marker-gray-color: #7c7c7c;
 
-.choices__list--dropdown {
-  z-index: 3000;
-}
-
 .tooltip {
   background: $dark-gray-color;
   color: $white-color;

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -30,9 +30,9 @@ template.innerHTML = String.raw`
       <button id="submit" class='button pan'>
         <i class="fas fa-search"></i>
       </button>
-      <div class="choices-container">
+      <!-- <div class="choices-container">
         <select id="source-list" multiple></select>
-      </div>
+      </div> -->
   </div>
 `;
 

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -5,13 +5,13 @@ import { getPan, parseRegionDesignation, zoomIn, zoomOut } from "../util/navigat
 const template = document.createElement("template");
 template.innerHTML = String.raw`
   <style>
-    .choices__inner {
+    /* .choices__inner {
       padding: 2px 6px;
       min-height: auto;
-    }
-    .choices-container {
+    } */
+    /* .choices-container {
       max-width: 300px;
-    }
+    } */
   </style>
   <div id="input-controls-container" style="display: flex; align-items: center; gap: 8px;">
       <button id="pan-left" class='button pan'>
@@ -112,15 +112,16 @@ export class InputControls extends HTMLElement {
   }
 
   getAnnotSources(): { id: string; label: string }[] {
-    const selectedObjs =
-      this.annotationSelectChoices.getValue() as EventChoice[];
-    const returnVals = selectedObjs.map((obj) => {
-      return {
-        id: obj.value,
-        label: obj.label.toString(),
-      };
-    });
-    return returnVals;
+    // const selectedObjs =
+    //   this.annotationSelectChoices.getValue() as EventChoice[];
+    // const returnVals = selectedObjs.map((obj) => {
+    //   return {
+    //     id: obj.value,
+    //     label: obj.label.toString(),
+    //   };
+    // });
+    // return returnVals;
+    return [];
   }
 
   getRange(): [number, number] {
@@ -154,26 +155,26 @@ export class InputControls extends HTMLElement {
     this.onPositionChange = onPositionChange;
     this.currChromLength = fullRegion.end;
 
-    // FIXME: Move this out from here
-    const choices: InputChoice[] = [];
-    for (const source of annotationSources) {
-      const choice = {
-        value: source.track_id,
-        label: source.name,
-        selected: defaultAnnots.includes(source.name),
-      };
-      choices.push(choice);
-    }
-    this.annotationSelectChoices.setChoices(choices);
+    // // FIXME: Move this out from here
+    // const choices: InputChoice[] = [];
+    // for (const source of annotationSources) {
+    //   const choice = {
+    //     value: source.track_id,
+    //     label: source.name,
+    //     selected: defaultAnnots.includes(source.name),
+    //   };
+    //   choices.push(choice);
+    // }
+    // this.annotationSelectChoices.setChoices(choices);
 
-    this.annotationSelectElement.addEventListener("change", async () => {
-      const selectedSources = this.annotationSelectChoices.getValue(
-        true,
-      ) as string[];
-      const region = parseRegionDesignation(this.regionField.value);
+    // this.annotationSelectElement.addEventListener("change", async () => {
+    //   const selectedSources = this.annotationSelectChoices.getValue(
+    //     true,
+    //   ) as string[];
+    //   const region = parseRegionDesignation(this.regionField.value);
 
-      onAnnotationChanged(region, selectedSources);
-    });
+    //   onAnnotationChanged(region, selectedSources);
+    // });
 
     this.panLeftButton.onclick = () => {
       this.panLeft();

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -1,18 +1,7 @@
-import Choices, { EventChoice, InputChoice } from "choices.js";
-import "choices.js/public/assets/styles/choices.min.css";
 import { getPan, parseRegionDesignation, zoomIn, zoomOut } from "../util/navigation";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`
-  <style>
-    /* .choices__inner {
-      padding: 2px 6px;
-      min-height: auto;
-    } */
-    /* .choices-container {
-      max-width: 300px;
-    } */
-  </style>
   <div id="input-controls-container" style="display: flex; align-items: center; gap: 8px;">
       <button id="pan-left" class='button pan'>
         <i class="fas fa-arrow-left"></i>
@@ -30,10 +19,6 @@ template.innerHTML = String.raw`
       <button id="submit" class='button pan'>
         <i class="fas fa-search"></i>
       </button>
-      <choice-select id="choice-select"></choice-select>
-      <!-- <div class="choices-container">
-        <select id="source-list" multiple></select>
-      </div> -->
   </div>
 `;
 
@@ -74,8 +59,6 @@ class RegionController {
 }
 
 export class InputControls extends HTMLElement {
-  private annotationSelectElement: HTMLSelectElement;
-  private annotationSelectChoices: Choices;
 
   private panLeftButton: HTMLButtonElement;
   private panRightButton: HTMLButtonElement;
@@ -91,16 +74,6 @@ export class InputControls extends HTMLElement {
   connectedCallback() {
     this.appendChild(template.content.cloneNode(true));
 
-    this.annotationSelectElement = this.querySelector(
-      "#source-list",
-    ) as HTMLSelectElement;
-
-    // this.annotationSelectChoices = new Choices(this.annotationSelectElement, {
-    //   placeholderValue: "Enter annotation",
-    //   removeItemButton: true,
-    //   itemSelectText: "",
-    // });
-
     this.panLeftButton = this.querySelector("#pan-left") as HTMLButtonElement;
     this.panRightButton = this.querySelector("#pan-right") as HTMLButtonElement;
     this.zoomInButton = this.querySelector("#zoom-in") as HTMLButtonElement;
@@ -110,19 +83,6 @@ export class InputControls extends HTMLElement {
 
   getRegion(): Region {
     return this.region.getRegion();
-  }
-
-  getAnnotSources(): { id: string; label: string }[] {
-    // const selectedObjs =
-    //   this.annotationSelectChoices.getValue() as EventChoice[];
-    // const returnVals = selectedObjs.map((obj) => {
-    //   return {
-    //     id: obj.value,
-    //     label: obj.label.toString(),
-    //   };
-    // });
-    // return returnVals;
-    return [];
   }
 
   getRange(): [number, number] {
@@ -146,36 +106,12 @@ export class InputControls extends HTMLElement {
 
   initialize(
     fullRegion: Region,
-    defaultAnnots: string[],
-    onAnnotationChanged: (region: Region, sources: string[]) => void,
     onPositionChange: (newXRange: [number, number]) => void,
-    annotationSources: ApiAnnotationTrack[],
   ) {
     this.region = new RegionController(fullRegion);
     this.updatePosition([fullRegion.start, fullRegion.end]);
     this.onPositionChange = onPositionChange;
     this.currChromLength = fullRegion.end;
-
-    // // FIXME: Move this out from here
-    // const choices: InputChoice[] = [];
-    // for (const source of annotationSources) {
-    //   const choice = {
-    //     value: source.track_id,
-    //     label: source.name,
-    //     selected: defaultAnnots.includes(source.name),
-    //   };
-    //   choices.push(choice);
-    // }
-    // this.annotationSelectChoices.setChoices(choices);
-
-    // this.annotationSelectElement.addEventListener("change", async () => {
-    //   const selectedSources = this.annotationSelectChoices.getValue(
-    //     true,
-    //   ) as string[];
-    //   const region = parseRegionDesignation(this.regionField.value);
-
-    //   onAnnotationChanged(region, selectedSources);
-    // });
 
     this.panLeftButton.onclick = () => {
       this.panLeft();

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -94,11 +94,11 @@ export class InputControls extends HTMLElement {
       "#source-list",
     ) as HTMLSelectElement;
 
-    this.annotationSelectChoices = new Choices(this.annotationSelectElement, {
-      placeholderValue: "Enter annotation",
-      removeItemButton: true,
-      itemSelectText: "",
-    });
+    // this.annotationSelectChoices = new Choices(this.annotationSelectElement, {
+    //   placeholderValue: "Enter annotation",
+    //   removeItemButton: true,
+    //   itemSelectText: "",
+    // });
 
     this.panLeftButton = this.querySelector("#pan-left") as HTMLButtonElement;
     this.panRightButton = this.querySelector("#pan-right") as HTMLButtonElement;

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -30,6 +30,7 @@ template.innerHTML = String.raw`
       <button id="submit" class='button pan'>
         <i class="fas fa-search"></i>
       </button>
+      <choice-select id="choice-select"></choice-select>
       <!-- <div class="choices-container">
         <select id="source-list" multiple></select>
       </div> -->

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -1,3 +1,4 @@
+import { ChoiceSelect } from "./util/choice_select";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 import Choices, { EventChoice, InputChoice } from "choices.js";
 // import "choices.js/public/assets/styles/choices.min.css";
@@ -6,18 +7,32 @@ const template = document.createElement("template");
 template.innerHTML = String.raw`
   <p>Hello world</p>
   <div class="choices-container">
-    <select id="source-list2" multiple></select>
+    <choice-select id="choice-select"></choice-select>
+    <!-- <select id="source-list" multiple>
+      <option value="volvo">Volvo</option>
+      <option value="saab">Saab</option>
+      <option value="mercedes">Mercedes</option>
+      <option value="audi">Audi</option>
+    </select> -->
   </div>
 `;
 
-export class SettingsPage extends HTMLElement {
+export class SettingsPage extends ShadowBaseElement {
   private selectElement: HTMLSelectElement;
   private annotationSelectChoices: Choices;
   private choices: InputChoice[];
 
+  private choiceSelect: ChoiceSelect;
+
   private annotationSources: ApiAnnotationTrack[];
   private defaultAnnots: string[];
   private onAnnotationChanged: (sources: string[]) => void;
+
+  constructor() {
+    super(template);
+    // this.selectElement = this.root.querySelector("#source-list");
+    this.choiceSelect = this.root.querySelector("#choice-select");
+  }
 
   initialize(
     annotationSources: ApiAnnotationTrack[],
@@ -33,48 +48,44 @@ export class SettingsPage extends HTMLElement {
 
   connectedCallback() {
 
-    if (!this.hasSetup) {
-      this.appendChild(template.content.cloneNode(true));
+    // if (!this.hasSetup) {
+    //   // this.appendChild(template.content.cloneNode(true));
 
-      this.selectElement = this.querySelector(
-        "#source-list2",
-      ) as HTMLSelectElement;  
-      console.log(this.selectElement);
-      this.annotationSelectChoices = new Choices(this.selectElement, {
-        placeholderValue: "Choose annotation",
-        removeItemButton: true,
-        itemSelectText: "",
-      });  
-      this.hasSetup = true;
-    }
+    //   // this.annotationSelectChoices = new Choices(this.selectElement, {
+    //   //   placeholderValue: "Choose annotation",
+    //   //   removeItemButton: true,
+    //   //   itemSelectText: "",
+    //   // });  
+    //   this.hasSetup = true;
+    // }
 
-    if (this.annotationSources == null) {
-      throw Error("Must be initialized before being connected")
-    }
+    // if (this.annotationSources == null) {
+    //   throw Error("Must be initialized before being connected")
+    // }
 
-    console.log(this.selectElement);
+    // console.log(this.selectElement);
 
-    const choices: InputChoice[] = [];
-    for (const source of this.annotationSources) {
-      const choice = {
-        value: source.track_id,
-        label: source.name,
-        selected: this.defaultAnnots.includes(source.name),
-      };
-      choices.push(choice);
-    }
+    // const choices: InputChoice[] = [];
+    // for (const source of this.annotationSources) {
+    //   const choice = {
+    //     value: source.track_id,
+    //     label: source.name,
+    //     selected: this.defaultAnnots.includes(source.name),
+    //   };
+    //   choices.push(choice);
+    // }
     // this.choices = choices;
-    this.annotationSelectChoices.setChoices(choices);
+    // this.annotationSelectChoices.setChoices(choices);
 
     // this.annotationSelectChoices.setChoices(this.choices);
 
-    this.selectElement.addEventListener("change", async () => {
-      const selectedSources = this.annotationSelectChoices.getValue(
-        true,
-      ) as string[];
+    // this.selectElement.addEventListener("change", async () => {
+    //   const selectedSources = this.annotationSelectChoices.getValue(
+    //     true,
+    //   ) as string[];
 
-      // onAnnotationChanged(selectedSources);
-    });
+    //   // onAnnotationChanged(selectedSources);
+    // });
   }
 
   getAnnotSources(): { id: string; label: string }[] {

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -7,6 +7,12 @@ const template = document.createElement("template");
 template.innerHTML = String.raw`
   <p>Hello world</p>
   <div class="choices-container">
+    <!-- <select multiple>
+      <option>A</option>
+      <option>B</option>
+      <option>C</option>
+    </select> -->
+
     <choice-select id="choice-select"></choice-select>
     <!-- <select id="source-list" multiple>
       <option value="volvo">Volvo</option>

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -1,0 +1,83 @@
+import { ShadowBaseElement } from "./util/shadowbaseelement";
+import Choices, { EventChoice, InputChoice } from "choices.js";
+import "choices.js/public/assets/styles/choices.min.css";
+
+const template = document.createElement("template");
+template.innerHTML = String.raw`
+<style>
+    /* import Choices’ styles so they apply inside shadow root */
+    @import url("https://cdnjs.cloudflare.com/ajax/libs/choices.js/10.2.0/styles/choices.min.css");
+  </style>
+
+  <p>Hello world</p>
+  <div class="choices-container">
+    <select id="source-list" multiple></select>
+  </div>
+`;
+
+export class SettingsPage extends ShadowBaseElement {
+  private selectElement: HTMLSelectElement;
+  private annotationSelectChoices: Choices;
+  private choices: InputChoice[];
+
+  constructor() {
+    super(template);
+  }
+
+  connectedCallback(): void {
+    this.selectElement = this.root.querySelector(
+      "#source-list",
+    ) as HTMLSelectElement;
+
+    this.annotationSelectChoices = new Choices(this.selectElement, {
+      placeholderValue: "Choose annotation",
+      removeItemButton: true,
+      itemSelectText: "",
+    });
+
+    this.annotationSelectChoices.setChoices(this.choices);
+
+    this.selectElement.addEventListener("change", async () => {
+      const selectedSources = this.annotationSelectChoices.getValue(
+        true,
+      ) as string[];
+
+      // onAnnotationChanged(selectedSources);
+    });
+  }
+
+  getAnnotSources(): { id: string; label: string }[] {
+    const selectedObjs =
+      this.annotationSelectChoices.getValue() as EventChoice[];
+    const returnVals = selectedObjs.map((obj) => {
+      return {
+        id: obj.value,
+        label: obj.label.toString(),
+      };
+    });
+    return returnVals;
+  }
+
+  initialize(
+    annotationSources: ApiAnnotationTrack[],
+    defaultAnnots: string[],
+    onAnnotationChanged: (sources: string[]) => void,
+  ) {
+
+    const choices: InputChoice[] = [];
+    for (const source of annotationSources) {
+      const choice = {
+        value: source.track_id,
+        label: source.name,
+        selected: defaultAnnots.includes(source.name),
+      };
+      choices.push(choice);
+    }
+    this.choices = choices;
+    // this.annotationSelectChoices.setChoices(choices);
+
+
+  }
+}
+
+customElements.define("settings-page", SettingsPage);

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -1,7 +1,6 @@
 import { ChoiceSelect } from "./util/choice_select";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
-import Choices, { EventChoice, InputChoice } from "choices.js";
-// import "choices.js/public/assets/styles/choices.min.css";
+import { InputChoice } from "choices.js";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`
@@ -53,7 +52,6 @@ export class SettingsPage extends ShadowBaseElement {
       return this.defaultAnnots;
     }
     const choices = this.choiceSelect.getChoices();
-    // return choices.map((choice) => choice.value);
     const returnVals = choices.map((obj) => {
       return {
         id: obj.value,

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -5,38 +5,24 @@ import Choices, { EventChoice, InputChoice } from "choices.js";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`
-  <p>Hello world</p>
+  <div>Annotation sources</div>
   <div class="choices-container">
-    <!-- <select multiple>
-      <option>A</option>
-      <option>B</option>
-      <option>C</option>
-    </select> -->
-
     <choice-select id="choice-select"></choice-select>
-    <!-- <select id="source-list" multiple>
-      <option value="volvo">Volvo</option>
-      <option value="saab">Saab</option>
-      <option value="mercedes">Mercedes</option>
-      <option value="audi">Audi</option>
-    </select> -->
   </div>
 `;
 
 export class SettingsPage extends ShadowBaseElement {
-  private selectElement: HTMLSelectElement;
-  private annotationSelectChoices: Choices;
-  private choices: InputChoice[];
-
   private choiceSelect: ChoiceSelect;
-
   private annotationSources: ApiAnnotationTrack[];
   private defaultAnnots: string[];
   private onAnnotationChanged: (sources: string[]) => void;
 
   constructor() {
     super(template);
-    // this.selectElement = this.root.querySelector("#source-list");
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
     this.choiceSelect = this.root.querySelector("#choice-select");
   }
 
@@ -45,59 +31,19 @@ export class SettingsPage extends ShadowBaseElement {
     defaultAnnots: string[],
     onAnnotationChanged: (sources: string[]) => void,
   ) {
+    console.log("Initialized");
     this.annotationSources = annotationSources;
-    this.defaultAnnots = defaultAnnots;    
+    this.defaultAnnots = defaultAnnots;
     this.onAnnotationChanged = onAnnotationChanged;
-  }
 
-  hasSetup = false;
-
-  connectedCallback() {
-
-    // if (!this.hasSetup) {
-    //   // this.appendChild(template.content.cloneNode(true));
-
-    //   // this.annotationSelectChoices = new Choices(this.selectElement, {
-    //   //   placeholderValue: "Choose annotation",
-    //   //   removeItemButton: true,
-    //   //   itemSelectText: "",
-    //   // });  
-    //   this.hasSetup = true;
-    // }
-
-    // if (this.annotationSources == null) {
-    //   throw Error("Must be initialized before being connected")
-    // }
-
-    // console.log(this.selectElement);
-
-    // const choices: InputChoice[] = [];
-    // for (const source of this.annotationSources) {
-    //   const choice = {
-    //     value: source.track_id,
-    //     label: source.name,
-    //     selected: this.defaultAnnots.includes(source.name),
-    //   };
-    //   choices.push(choice);
-    // }
-    // this.choices = choices;
-    // this.annotationSelectChoices.setChoices(choices);
-
-    // this.annotationSelectChoices.setChoices(this.choices);
-
-    // this.selectElement.addEventListener("change", async () => {
-    //   const selectedSources = this.annotationSelectChoices.getValue(
-    //     true,
-    //   ) as string[];
-
-    //   // onAnnotationChanged(selectedSources);
-    // });
+    this.choiceSelect.setChoices(
+      getChoices(this.annotationSources, this.defaultAnnots),
+    );
   }
 
   getAnnotSources(): { id: string; label: string }[] {
-    const selectedObjs =
-      this.annotationSelectChoices.getValue() as EventChoice[];
-    const returnVals = selectedObjs.map((obj) => {
+    const choices = this.choiceSelect.getChoices();
+    const returnVals = choices.map((obj) => {
       return {
         id: obj.value,
         label: obj.label.toString(),
@@ -105,8 +51,22 @@ export class SettingsPage extends ShadowBaseElement {
     });
     return returnVals;
   }
+}
 
-
+function getChoices(
+  annotationSources: ApiAnnotationTrack[],
+  defaultAnnots: string[],
+): InputChoice[] {
+  const choices: InputChoice[] = [];
+  for (const source of annotationSources) {
+    const choice = {
+      value: source.track_id,
+      label: source.name,
+      selected: defaultAnnots.includes(source.name),
+    };
+    choices.push(choice);
+  }
+  return choices;
 }
 
 customElements.define("settings-page", SettingsPage);

--- a/assets/js/components/side_menu.ts
+++ b/assets/js/components/side_menu.ts
@@ -118,25 +118,21 @@ template.innerHTML = String.raw`
   </div>
 `;
 
-export class SideMenu extends ShadowBaseElement {
+export class SideMenu extends HTMLElement {
   private drawer!: HTMLElement;
   private closeButton!: HTMLButtonElement;
   private header!: HTMLDivElement;
   private entries!: HTMLDivElement;
 
-  constructor() {
-    super(template);
-  }
-
   connectedCallback() {
-    super.connectedCallback();
-    this.drawer = this.root.querySelector("#settings-drawer") as HTMLElement;
-    this.closeButton = this.root.querySelector(
+    this.appendChild(template.content.cloneNode(true));
+    this.drawer = this.querySelector("#settings-drawer") as HTMLElement;
+    this.closeButton = this.querySelector(
       "#close-drawer",
     ) as HTMLButtonElement;
 
-    this.header = this.root.querySelector("#header") as HTMLDivElement;
-    this.entries = this.root.querySelector("#entries") as HTMLDivElement;
+    this.header = this.querySelector("#header") as HTMLDivElement;
+    this.entries = this.querySelector("#entries") as HTMLDivElement;
 
     this.closeButton.addEventListener("click", () => {
       this.removeAttribute("drawer-open");

--- a/assets/js/components/side_menu.ts
+++ b/assets/js/components/side_menu.ts
@@ -118,21 +118,25 @@ template.innerHTML = String.raw`
   </div>
 `;
 
-export class SideMenu extends HTMLElement {
+export class SideMenu extends ShadowBaseElement {
   private drawer!: HTMLElement;
   private closeButton!: HTMLButtonElement;
   private header!: HTMLDivElement;
   private entries!: HTMLDivElement;
 
+  constructor() {
+    super(template);
+  }
+
   connectedCallback() {
-    this.appendChild(template.content.cloneNode(true));
-    this.drawer = this.querySelector("#settings-drawer") as HTMLElement;
-    this.closeButton = this.querySelector(
+    super.connectedCallback();
+    this.drawer = this.root.querySelector("#settings-drawer") as HTMLElement;
+    this.closeButton = this.root.querySelector(
       "#close-drawer",
     ) as HTMLButtonElement;
 
-    this.header = this.querySelector("#header") as HTMLDivElement;
-    this.entries = this.querySelector("#entries") as HTMLDivElement;
+    this.header = this.root.querySelector("#header") as HTMLDivElement;
+    this.entries = this.root.querySelector("#entries") as HTMLDivElement;
 
     this.closeButton.addEventListener("click", () => {
       this.removeAttribute("drawer-open");

--- a/assets/js/components/side_menu.ts
+++ b/assets/js/components/side_menu.ts
@@ -166,7 +166,7 @@ export class SideMenu extends ShadowBaseElement {
     }
   }
 
-  showContent(header: string, content: HTMLDivElement[]) {
+  showContent(header: string, content: HTMLElement[]) {
     this.open();
 
     removeChildren(this.entries);

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -10,6 +10,7 @@ import {
 
 const X_PAD = 5;
 const DOT_SIZE = 2;
+const PIXEL_RATIO = 2;
 
 export class OverviewTrack extends CanvasTrack {
   totalChromSize: number;
@@ -24,7 +25,8 @@ export class OverviewTrack extends CanvasTrack {
   renderData: OverviewTrackData | null;
   getRenderData: () => Promise<OverviewTrackData>;
 
-  // FIXME: Generalize this
+  // FIXME: Temporary solution to make sure the overview plots are rendered
+  // efficiently. This should likely be generalized and part of Canvas track.
   private staticBuffer: HTMLCanvasElement;
   private staticCtx: CanvasRenderingContext2D;
 
@@ -66,7 +68,6 @@ export class OverviewTrack extends CanvasTrack {
   }
 
   async render(updateData: boolean) {
-    const pixelRatio = 2;
 
     let newRender = false;
     if (this.renderData == null || updateData) {
@@ -100,10 +101,10 @@ export class OverviewTrack extends CanvasTrack {
       this.renderLoading();
 
       // Sync the static canvas sizes
-      this.staticBuffer.width = this.dimensions.width * pixelRatio;
-      this.staticBuffer.height = this.dimensions.height * pixelRatio;
+      this.staticBuffer.width = this.dimensions.width * PIXEL_RATIO;
+      this.staticBuffer.height = this.dimensions.height * PIXEL_RATIO;
       this.staticCtx.resetTransform();
-      this.staticCtx.scale(pixelRatio, pixelRatio);
+      this.staticCtx.scale(PIXEL_RATIO, PIXEL_RATIO);
 
       renderBackground(this.staticCtx, this.dimensions, STYLE.tracks.edgeColor);
       renderOverviewPlot(

--- a/assets/js/components/util/choice_select.ts
+++ b/assets/js/components/util/choice_select.ts
@@ -1,6 +1,47 @@
 import Choices, { EventChoice, InputChoice } from "choices.js";
 import { ShadowBaseElement } from "./shadowbaseelement";
 
+// https://github.com/Choices-js/Choices/issues/805
+
+// onClick does not seem to play well with being inside a shadow DOM
+// Some adjustments were needed
+Choices.prototype._onClick = function (event: MouseEvent) {
+
+  // Previously the target ended up on outside the shadow DOM components
+  // var target = event.target;
+
+  // Now, getting the full path where we can check inside the shadow DOM whether
+  // the select is clicked
+  const path = event.composedPath?.() || [];
+  var containerOuter = this.containerOuter;
+  var clickWasWithinContainer = path.includes(containerOuter.element);
+
+  // Previous line
+  // var clickWasWithinContainer = containerOuter.element.contains(target);
+  if (clickWasWithinContainer) {
+    if (!this.dropdown.isActive && !containerOuter.isDisabled) {
+      if (this._isTextElement) {
+        if (document.activeElement !== this.input.element) {
+          this.input.focus();
+        }
+      } else {
+        this.showDropdown();
+        containerOuter.element.focus();
+      }
+    } else if (
+      this._isSelectOneElement &&
+      event.target !== this.input.element &&
+      !this.dropdown.element.contains(event.target)
+    ) {
+      this.hideDropdown();
+    }
+  } else {
+    containerOuter.removeFocusState();
+    this.hideDropdown(true);
+    this.unhighlightAll();
+  }
+};
+
 const template = document.createElement("template");
 template.innerHTML = String.raw`
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
@@ -11,7 +52,7 @@ template.innerHTML = String.raw`
   </style>
   <select id="select" multiple>
     <option value="volvo">A</option>
-    <option value="saab">B</option>
+    <option value="saab">BC</option>
   </select>
 `;
 
@@ -26,11 +67,6 @@ export class ChoiceSelect extends ShadowBaseElement {
       placeholderValue: "Choices",
       removeItemButton: true,
       itemSelectText: "",
-    });
-
-    // Test trying to prevent clicks to be captured elsewhere
-    this.selectElement.addEventListener("change", (e) => {
-      console.log("Changed");
     });
   }
 

--- a/assets/js/components/util/choice_select.ts
+++ b/assets/js/components/util/choice_select.ts
@@ -4,7 +4,11 @@ import { ShadowBaseElement } from "./shadowbaseelement";
 const template = document.createElement("template");
 template.innerHTML = String.raw`
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
-  <p>Header</p>
+  <style>
+    .choices__list--dropdown {
+      z-index: 3000;
+    }
+  </style>
   <select id="select" multiple>
     <option value="volvo">A</option>
     <option value="saab">B</option>
@@ -22,6 +26,11 @@ export class ChoiceSelect extends ShadowBaseElement {
       placeholderValue: "Choices",
       removeItemButton: true,
       itemSelectText: "",
+    });
+
+    // Test trying to prevent clicks to be captured elsewhere
+    this.selectElement.addEventListener("change", (e) => {
+      console.log("Changed");
     });
   }
 

--- a/assets/js/components/util/choice_select.ts
+++ b/assets/js/components/util/choice_select.ts
@@ -1,0 +1,33 @@
+import Choices, { EventChoice, InputChoice } from "choices.js";
+import { ShadowBaseElement } from "./shadowbaseelement";
+
+const template = document.createElement("template");
+template.innerHTML = String.raw`
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
+  <p>Header</p>
+  <select id="select" multiple>
+    <option value="volvo">A</option>
+    <option value="saab">B</option>
+  </select>
+`;
+
+export class ChoiceSelect extends ShadowBaseElement {
+  private selectElement: HTMLSelectElement;
+  private choiceElement: Choices;
+
+  constructor() {
+    super(template);
+    this.selectElement = this.root.querySelector("#select");
+    this.choiceElement = new Choices(this.selectElement, {
+      placeholderValue: "Choices",
+      removeItemButton: true,
+      itemSelectText: "",
+    });
+  }
+
+  initialize() {}
+
+  connectedCallback(): void {}
+}
+
+customElements.define("choice-select", ChoiceSelect);

--- a/assets/js/components/util/choice_select.ts
+++ b/assets/js/components/util/choice_select.ts
@@ -75,9 +75,12 @@ export class ChoiceSelect extends ShadowBaseElement {
     return this.choiceElement.getValue() as EventChoice[];
   }
 
-  initialize() {}
-
-  connectedCallback(): void {}
+  initialize(changeCallback: (choiceIds: string[]) => void) {
+    this.selectElement.addEventListener("change", () => {
+      const selectedIds = this.choiceElement.getValue(true) as string[];
+      changeCallback(selectedIds);
+    })
+  }
 }
 
 customElements.define("choice-select", ChoiceSelect);

--- a/assets/js/components/util/choice_select.ts
+++ b/assets/js/components/util/choice_select.ts
@@ -50,10 +50,7 @@ template.innerHTML = String.raw`
       z-index: 3000;
     }
   </style>
-  <select id="select" multiple>
-    <option value="volvo">A</option>
-    <option value="saab">BC</option>
-  </select>
+  <select id="select" multiple></select>
 `;
 
 export class ChoiceSelect extends ShadowBaseElement {
@@ -68,6 +65,14 @@ export class ChoiceSelect extends ShadowBaseElement {
       removeItemButton: true,
       itemSelectText: "",
     });
+  }
+
+  setChoices(choices: InputChoice[]) {
+    this.choiceElement.setChoices(choices);
+  }
+
+  getChoices(): EventChoice[] {
+    return this.choiceElement.getValue() as EventChoice[];
   }
 
   initialize() {}

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -139,8 +139,6 @@ export async function initCanvases({
     "settings-button",
   ) as HTMLDivElement;
   settingsButton.addEventListener("click", () => {
-    // content.appendChild(inputControls)
-    // content.innerHTML = "Settings content";
     sideMenu.showContent("Settings", [settingsPage]);
 
     if (!settingsPage.isInitialized) {

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -2,6 +2,7 @@ import "./components/tracks_manager";
 import "./components/input_controls";
 import "./components/util/popup";
 import "./components/util/shadowbaseelement";
+import "./components/util/choice_select";
 import "./components/side_menu";
 import "./components/settings_page";
 
@@ -48,6 +49,7 @@ export async function initCanvases({
     // content.appendChild(inputControls)
     // content.innerHTML = "Settings content";
     sideMenu.showContent("Settings", [settingsPage]);
+    // sideMenu.showContent("Settings", []);
   });
 
   const api = new API(sampleId, caseId, genomeBuild, gensApiURL);

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -3,6 +3,7 @@ import "./components/input_controls";
 import "./components/util/popup";
 import "./components/util/shadowbaseelement";
 import "./components/side_menu";
+import "./components/settings_page";
 
 import { API } from "./state/api";
 import { TracksManager } from "./components/tracks_manager";
@@ -10,6 +11,7 @@ import { InputControls } from "./components/input_controls";
 import { getRenderDataSource } from "./state/parse_data";
 import { CHROMOSOMES } from "./constants";
 import { SideMenu } from "./components/side_menu";
+import { SettingsPage } from "./components/settings_page";
 
 export async function initCanvases({
   sampleId,
@@ -33,18 +35,20 @@ export async function initCanvases({
 
   const sideMenu = document.getElementById("side-menu") as SideMenu;
 
+  const inputControls = document.getElementById(
+    "input-controls",
+  ) as InputControls;
+
+  const settingsPage = new SettingsPage();
+
   const settingsButton = document.getElementById(
     "settings-button",
   ) as HTMLDivElement;
   settingsButton.addEventListener("click", () => {
-    const content = document.createElement("div");
-    content.innerHTML = "Settings content";
-    sideMenu.showContent("Settings", [content]);
+    // content.appendChild(inputControls)
+    // content.innerHTML = "Settings content";
+    sideMenu.showContent("Settings", [settingsPage]);
   });
-
-  const inputControls = document.getElementById(
-    "input-controls",
-  ) as InputControls;
 
   const api = new API(sampleId, caseId, genomeBuild, gensApiURL);
 
@@ -115,6 +119,7 @@ export async function initCanvases({
 
   initialize(
     inputControls,
+    settingsPage,
     gensTracks,
     startRegion,
     annotationFile,
@@ -129,6 +134,7 @@ export async function initCanvases({
 
 async function initialize(
   inputControls: InputControls,
+  settingsPage: SettingsPage,
   tracks: TracksManager,
   startRegion: Region,
   defaultAnnotation: string,
@@ -159,6 +165,10 @@ async function initialize(
     },
     annotSources,
   );
+
+  settingsPage.initialize(annotSources, [defaultAnnotation], (source) => {
+    console.log("Changed to source", source);
+  })
 
   await tracks.initialize(
     chromSizes,

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -73,7 +73,6 @@ export class API {
       this.annotsCache[trackId] = annotations;
     }
 
-    console.log("Returning from cache", this.annotsCache);
     return this.annotsCache[trackId];
   }
 

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -21,6 +21,7 @@
 {% block scripts %}
     <script src='{{ url_for('gens.static', filename='gens.min.js') }}'></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
 {% endblock scripts %}
 
 {% macro loading() %}

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -22,6 +22,7 @@
     <script src='{{ url_for('gens.static', filename='gens.min.js') }}'></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"/>
+
 {% endblock scripts %}
 
 {% macro loading() %}
@@ -36,6 +37,9 @@
 
 {% block body %}
 <!-- {{ loading() }} -->
+
+<choicesjs-stencil values="foo,bar"></choicesjs-stencil>
+
 <div id='main-container'>
 
   <side-menu id="side-menu"></side-menu>

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -38,8 +38,6 @@
 {% block body %}
 <!-- {{ loading() }} -->
 
-<choicesjs-stencil values="foo,bar"></choicesjs-stencil>
-
 <div id='main-container'>
 
   <side-menu id="side-menu"></side-menu>


### PR DESCRIPTION
Various fixes to get annotations running on Gens dev.

Backend

* Parsing annotations allows a more liberal option to skip errors `--ignore-errors`. Currently only active for aed files. We should work through the errors and probably many of these can be fixed by our users. The current crash only was too blocking though.
* Extract the choices select component into its own web component.
* Move the annotations select into the setting side bar. In the future, more selects will be there (sample annotations, panels (?)).

Moving the annotation select into the side bar turned out to be a bit tricky due to how event targeting works with the shadow dom, and due to that Choices had not yet been adapted for this. A prototype update of the imported Choices component resolved this.