### PR TITLE
Moving, hiding, collapsing tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Highlight regions and see these highlights across all the position tracks.
  - View multiple coverage tracks for samples within a case.
  - Renderings are debounced and keep track of the last render such that they not double-render
+ - Tracks can be shown / hidden, collapsed and moved
 
 ### Changed
  - Resolution increased 2x for tracks.

--- a/assets/css/gens.scss
+++ b/assets/css/gens.scss
@@ -8,7 +8,7 @@ $gens-blue: #567;
 // FIXME: Merge with other colors
 $button-white: #FAFBFC;
 $button-black: rgba(27, 31, 35, 0.15);
-$button-gray: #888;
+$button-gray: #444;
 $button-hover-white: #E7EEF2;
 $header-background-blue: #bbcadc;
 $source-border-color: rgba(27, 31, 35, 0.15);
@@ -82,7 +82,7 @@ $marker-gray-color: #7c7c7c;
   align-items: center;
   justify-content: center;
 
-  i {
+  .fas {
     font-size: 20px;
     line-height: 1;
     color: $button-gray;

--- a/assets/js/components/header_info.ts
+++ b/assets/js/components/header_info.ts
@@ -1,4 +1,4 @@
-import { COLORS, FONT_SIZE, FONT_WEIGHT, PAD } from "../constants";
+import { COLORS, FONT_SIZE, FONT_WEIGHT, SIZES } from "../constants";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 
 const template = document.createElement("template");
@@ -9,12 +9,12 @@ template.innerHTML = String.raw`
     flex-direction: column;
     justify-content: center;
     height: 100%;
-    padding-left: ${PAD.s}px;
+    padding-left: ${SIZES.s}px;
   }
   .row {
     display: flex;
     flex-direction: row;
-    padding-top: ${PAD.xs}px;
+    padding-top: ${SIZES.xs}px;
     justify-content: space-between;
   }
   .text {
@@ -23,7 +23,7 @@ template.innerHTML = String.raw`
   }
   .label {
     font-weight: ${FONT_WEIGHT.header};
-    padding-right: ${PAD.xs}px;
+    padding-right: ${SIZES.xs}px;
   }
 </style>
 <div id="container">

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -9,7 +9,7 @@ const template = document.createElement("template");
 template.innerHTML = String.raw`
   <div id="input-controls-container" style="display: flex; align-items: center; gap: 8px;">
       <button title="Pan left" id="pan-left" class='button pan'>
-        <i class="fas fa-arrow-left"></i>
+        <span class="fas fa-arrow-left"></span>
       </button>
       <button title="Zoom in" id="zoom-in" class='button zoom'>
         <i class="fas fa-search-plus"></i>

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -12,21 +12,21 @@ template.innerHTML = String.raw`
         <span class="fas fa-arrow-left"></span>
       </button>
       <button title="Zoom in" id="zoom-in" class='button zoom'>
-        <i class="fas fa-search-plus"></i>
+        <span class="fas fa-search-plus"></span>
       </button>
       <button title="Zoom out" id="zoom-out" class='button zoom'>
-        <i class="fas fa-search-minus"></i>
+        <span class="fas fa-search-minus"></span>
       </button>
       <button title="Pan right" id="pan-right" class='button pan'>
-        <i class="fas fa-arrow-right"></i>
+        <span class="fas fa-arrow-right"></span>
       </button>
       <input onFocus='this.select();' id='region-field' type='text' class="text-input">
       <button title="Run search" id="submit" class='button pan'>
-        <i class="fas fa-search"></i>
+        <span class="fas fa-search"></span>
       </button>
-      <button title="Remove highlights" id="remove-highlights" class='button pan'>
-        <i class="fas fa-xmark"></i>
-      </button>
+      <!-- <button title="Remove highlights" id="remove-highlights" class='button pan'>
+        <span class="fas fa-xmark"></span>
+      </button> -->
   </div>
 `;
 

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -1,3 +1,4 @@
+import { DataTrack } from "./tracks/base_tracks/data_track";
 import { ChoiceSelect } from "./util/choice_select";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 import { InputChoice } from "choices.js";
@@ -8,6 +9,8 @@ template.innerHTML = String.raw`
   <div class="choices-container">
     <choice-select id="choice-select"></choice-select>
   </div>
+  <div>Tracks</div>
+  <div id="tracks-overview"></div>
 `;
 
 export class SettingsPage extends ShadowBaseElement {
@@ -15,6 +18,8 @@ export class SettingsPage extends ShadowBaseElement {
   private annotationSources: ApiAnnotationTrack[];
   private defaultAnnots: {id: string, label: string}[];
   private onAnnotationChanged: (sources: string[]) => void;
+  private getDataTracks: () => DataTrack[];
+  private tracksOverview: HTMLDivElement;
 
   public isInitialized: boolean = false;
 
@@ -24,18 +29,8 @@ export class SettingsPage extends ShadowBaseElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.choiceSelect = this.root.querySelector("#choice-select");
-  }
-
-  // Data 
-  setSources(
-    annotationSources: ApiAnnotationTrack[],
-    defaultAnnots: {id: string, label: string}[],
-    onAnnotationChanged: (sources: string[]) => void,
-  ) {
-    this.annotationSources = annotationSources;
-    this.defaultAnnots = defaultAnnots;
-    this.onAnnotationChanged = onAnnotationChanged;
+    this.choiceSelect = this.root.querySelector("#choice-select") as ChoiceSelect;
+    this.tracksOverview = this.root.querySelector("#tracks-overview") as HTMLDivElement;
   }
 
   initialize(
@@ -45,6 +40,25 @@ export class SettingsPage extends ShadowBaseElement {
       getChoices(this.annotationSources, this.defaultAnnots.map((a) => a.id)),
     );
     this.choiceSelect.initialize(this.onAnnotationChanged);
+
+    const tracks = this.getDataTracks();
+    for (const track of tracks) {
+      const trackDiv = document.createElement("div");
+      trackDiv.innerHTML = track.label;
+      this.tracksOverview.appendChild(trackDiv);
+    }
+  }
+
+  setSources(
+    annotationSources: ApiAnnotationTrack[],
+    defaultAnnots: {id: string, label: string}[],
+    onAnnotationChanged: (sources: string[]) => void,
+    getDataTracks: () => DataTrack[]
+  ) {
+    this.annotationSources = annotationSources;
+    this.defaultAnnots = defaultAnnots;
+    this.onAnnotationChanged = onAnnotationChanged;
+    this.getDataTracks = getDataTracks;
   }
 
   getAnnotSources(): {id: string, label: string}[] {

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -95,7 +95,7 @@ export class SettingsPage extends ShadowBaseElement {
         this.onChange();
       },
       (track: DataTrack) => {
-        track.isHidden = !track.isHidden;
+        track.toggleHidden();
         this.onChange();
       },
       (track: DataTrack) => {
@@ -185,7 +185,7 @@ function getTracksSection(
     );
     buttonsDiv.appendChild(
       getIconButton(
-        track.isHidden ? "fa-eye-slash" : "fa-eye",
+        track.getIsHidden() ? "fa-eye-slash" : "fa-eye",
         "Show / hide",
         () => onToggleShow(track),
       ),

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -1,4 +1,4 @@
-import { COLORS } from "../constants";
+import { COLORS, ICONS, SIZES } from "../constants";
 import { removeChildren } from "../util/utils";
 import { DataTrack } from "./tracks/base_tracks/data_track";
 import { ChoiceSelect } from "./util/choice_select";
@@ -11,24 +11,24 @@ template.innerHTML = String.raw`
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
     .header {
-      padding-top: 5px;
+      padding-top: ${SIZES.xs}px;
     }
     .row {
       display: flex;
       flex-direction: row;
-      padding-top: 2px;
+      padding-top: ${SIZES.xxs}px;
       align-items: center;
     }
     .icon-button {
-      height: 12px;
-      width: 12px;
+      height: ${SIZES.l}px;
+      width: ${SIZES.l}px;
       display: flex;
       flex-direction: row;
       align-items: center;
       justify-content: center;
     }
     .icon-button:hover {
-      background: #E7EEF2;
+      background: ${COLORS.extraLightGray};
     }
     /* FIXME: Nicer button response colors */
     .icon-button:active {
@@ -90,7 +90,7 @@ export class SettingsPage extends ShadowBaseElement {
     const tracks = this.getDataTracks();
     const tracksSection = getTracksSection(
       tracks,
-      (track: DataTrack, direction: "up" | "down") => { 
+      (track: DataTrack, direction: "up" | "down") => {
         this.onTrackMove(track.id, direction);
         this.onChange();
       },
@@ -175,24 +175,24 @@ function getTracksSection(
     buttonsDiv.style.display = "flex";
     buttonsDiv.style.flexDirection = "row";
     buttonsDiv.style.flexWrap = "nowrap";
-    buttonsDiv.style.gap = "0.5rem";
+    buttonsDiv.style.gap = `${SIZES.s}rem`;
 
     buttonsDiv.appendChild(
-      getIconButton("fa-arrow-up", "Up", () => onMove(track, "up")),
+      getIconButton(ICONS.up, "Up", () => onMove(track, "up")),
     );
     buttonsDiv.appendChild(
-      getIconButton("fa-arrow-down", "Down", () => onMove(track, "down")),
+      getIconButton(ICONS.down, "Down", () => onMove(track, "down")),
     );
     buttonsDiv.appendChild(
       getIconButton(
-        track.getIsHidden() ? "fa-eye-slash" : "fa-eye",
+        track.getIsHidden() ? ICONS.hide : ICONS.show,
         "Show / hide",
         () => onToggleShow(track),
       ),
     );
     buttonsDiv.appendChild(
       getIconButton(
-        track.getIsCollapsed() ? "fa-maximize" : "fa-minimize",
+        track.getIsCollapsed() ? ICONS.maximize : ICONS.minimize,
         "Collapse / expand",
         () => onToggleCollapse(track),
       ),

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -1,5 +1,7 @@
 import { DataTrack } from "./tracks/base_tracks/data_track";
+import { getButton } from "./tracks_manager";
 import { ChoiceSelect } from "./util/choice_select";
+import { getContainer } from "./util/menu_utils";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 import { InputChoice } from "choices.js";
 
@@ -43,8 +45,15 @@ export class SettingsPage extends ShadowBaseElement {
 
     const tracks = this.getDataTracks();
     for (const track of tracks) {
-      const trackDiv = document.createElement("div");
-      trackDiv.innerHTML = track.label;
+      const trackDiv = getContainer("row");
+      trackDiv.style.display = "flex";
+      trackDiv.style.flexDirection = "row";
+      trackDiv.style.alignItems = "center";
+      trackDiv.appendChild(document.createTextNode(track.label));
+      trackDiv.appendChild(getButton("Show", () => {}))
+      trackDiv.appendChild(getButton("Hide", () => {}))
+      trackDiv.appendChild(getButton("Up", () => {}))
+      trackDiv.appendChild(getButton("Down", () => {}))
       this.tracksOverview.appendChild(trackDiv);
     }
   }

--- a/assets/js/components/settings_page.ts
+++ b/assets/js/components/settings_page.ts
@@ -99,7 +99,7 @@ export class SettingsPage extends ShadowBaseElement {
         this.onChange();
       },
       (track: DataTrack) => {
-        track.isCollapsed = !track.isCollapsed;
+        track.toggleCollapsed();
         this.onChange();
       },
     );
@@ -192,7 +192,7 @@ function getTracksSection(
     );
     buttonsDiv.appendChild(
       getIconButton(
-        track.isCollapsed ? "fa-maximize" : "fa-minimize",
+        track.getIsCollapsed() ? "fa-maximize" : "fa-minimize",
         "Collapse / expand",
         () => onToggleCollapse(track),
       ),

--- a/assets/js/components/side_menu.ts
+++ b/assets/js/components/side_menu.ts
@@ -1,4 +1,4 @@
-import { FONT_SIZE, FONT_WEIGHT, PAD, STYLE, ZINDICES } from "../constants";
+import { FONT_SIZE, FONT_WEIGHT, SIZES, STYLE, ZINDICES } from "../constants";
 import { removeChildren } from "../util/utils";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 
@@ -16,7 +16,7 @@ template.innerHTML = String.raw`
 
     .menu-row {
       align-items: center;
-      padding: ${PAD.xs}px 0px;
+      padding: ${SIZES.xs}px 0px;
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -39,7 +39,7 @@ template.innerHTML = String.raw`
     }
 
     .section-entry {
-      padding: ${PAD.xxs}px 0;
+      padding: ${SIZES.xxs}px 0;
     }
 
     #settings-drawer {
@@ -78,7 +78,7 @@ template.innerHTML = String.raw`
     #entries {
       display: flex;
       flex-direction: column;
-      gap: ${PAD.l}px;
+      gap: ${SIZES.l}px;
       font-weight: ${FONT_WEIGHT.bold};
       font-size: ${FONT_SIZE.medium}px;
     }

--- a/assets/js/components/tracks/band_track.ts
+++ b/assets/js/components/tracks/band_track.ts
@@ -130,8 +130,9 @@ export class BandTrack extends DataTrack {
 
   setExpandedTrackHeight(numberLanes: number, showDetails: boolean) {
     const style = STYLE.bandTrack;
+    const height = STYLE.tracks.trackHeight.thin;
     const expandedHeight = getTrackHeight(
-      style.trackHeight.thin,
+      height,
       numberLanes,
       style.trackPadding,
       style.bandPadding,

--- a/assets/js/components/tracks/band_track.ts
+++ b/assets/js/components/tracks/band_track.ts
@@ -20,6 +20,7 @@ export class BandTrack extends DataTrack {
     getRenderData: () => Promise<BandTrackData>,
     openContextMenu: (id: string) => void,
     dragCallbacks: DragCallbacks,
+    openTrackContextMenu: (track: DataTrack) => void,
   ) {
     super(
       id,
@@ -35,6 +36,7 @@ export class BandTrack extends DataTrack {
         return xScale;
       },
       dragCallbacks,
+      openTrackContextMenu,
       {
         defaultHeight: trackHeight,
         dragSelect: true,
@@ -62,7 +64,7 @@ export class BandTrack extends DataTrack {
   }
 
   draw() {
-    super.draw();
+    super.drawStart();
 
     const { bands, xRange } = this.renderData as BandTrackData;
     const ntsPerPx = this.getNtsPerPixel(xRange);
@@ -122,7 +124,8 @@ export class BandTrack extends DataTrack {
     });
 
     this.setHoverTargets(hoverTargets);
-    this.drawTrackLabel();
+
+    this.drawEnd();
   }
 
   setExpandedTrackHeight(numberLanes: number, showDetails: boolean) {

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -5,6 +5,7 @@ import { Tooltip } from "../../../util/tooltip_utils";
 
 import { ShadowBaseElement } from "../../util/shadowbaseelement";
 import { eventInBox } from "../../../util/utils";
+import { getCanvasClick, getCanvasHover } from "../../util/canvas_interaction";
 
 // FIXME: Move somewhere
 const PADDING_SIDES = 0;
@@ -61,11 +62,7 @@ export class CanvasTrack extends ShadowBaseElement {
     return this.expander.isExpanded;
   }
 
-  constructor(
-    id: string,
-    label: string,
-    defaultHeight: number,
-  ) {
+  constructor(id: string, label: string, defaultHeight: number) {
     super(template);
 
     this.id = id;
@@ -95,7 +92,6 @@ export class CanvasTrack extends ShadowBaseElement {
     }
 
     this.canvas = this.root.getElementById("canvas") as HTMLCanvasElement;
-
     this.currentHeight = this.defaultTrackHeight;
     this.ctx = this.canvas.getContext("2d") as CanvasRenderingContext2D;
 
@@ -104,7 +100,6 @@ export class CanvasTrack extends ShadowBaseElement {
     ) as HTMLDivElement;
 
     this.syncDimensions();
-
     this.isInitialized = true;
   }
 
@@ -143,70 +138,37 @@ export class CanvasTrack extends ShadowBaseElement {
   }
 
   initializeClick(onElementClick: (el: HoverBox) => void | null = null) {
-    this.canvas.addEventListener("click", (event) => {
-      if (!this.hoverTargets || !onElementClick) {
-        return;
-      }
-
-      const hoveredTarget = this.hoverTargets.find((target) =>
-        eventInBox(event, target.box),
-      );
-
-      if (hoveredTarget && onElementClick) {
-        onElementClick(hoveredTarget);
-      }
-    });
-
-    this.canvas.addEventListener("mousemove", (event) => {
-      if (!this.hoverTargets) {
-        return;
-      }
-      const hovered = this.hoverTargets.find((target) =>
-        eventInBox(event, target.box),
-      );
-      if (onElementClick) {
-        this.canvas.style.cursor = hovered ? "pointer" : "default";
-      }
-    });
+    getCanvasClick(this.canvas, () => this.hoverTargets, onElementClick);
   }
 
   initializeHoverTooltip() {
-    const tooltip = new Tooltip(document.body);
+    getCanvasHover(this.canvas, () => this.hoverTargets, { showTooltip: true });
 
-    this.canvas.addEventListener("mousemove", (event) => {
-      if (this.hoverTargets == null) {
-        return;
-      }
-      tooltip.onMouseMove(this.canvas, event.offsetX, event.offsetY);
+    // const tooltip = new Tooltip(document.body);
+    // this.canvas.addEventListener("mousemove", (event) => {
+    //   if (this.hoverTargets == null) {
+    //     return;
+    //   }
+    //   tooltip.onMouseMove(this.canvas, event.offsetX, event.offsetY);
 
-      const hovered = this.hoverTargets.find((target) =>
-        eventInBox(event, target.box),
-      );
+    //   const hovered = this.hoverTargets.find((target) =>
+    //     eventInBox(event, target.box),
+    //   );
 
-      if (hovered) {
-        tooltip.tooltipEl.textContent = hovered.label;
-        tooltip.onMouseMove(this.canvas, event.offsetX, event.offsetY);
-      } else {
-        tooltip.onMouseLeave();
-      }
-    });
-    this.canvas.addEventListener("mouseleave", () => {
-      tooltip.onMouseLeave();
-    });
+    //   if (hovered) {
+    //     tooltip.tooltipEl.textContent = hovered.label;
+    //     tooltip.onMouseMove(this.canvas, event.offsetX, event.offsetY);
+    //   } else {
+    //     tooltip.onMouseLeave();
+    //   }
+    // });
+    // this.canvas.addEventListener("mouseleave", () => {
+    //   tooltip.onMouseLeave();
+    // });
   }
 
   setHoverTargets(hoverTargets: HoverBox[]) {
     this.hoverTargets = hoverTargets;
-  }
-
-  drawTrackLabel(shiftRight: number = 0) {
-    drawLabel(
-      this.ctx,
-      this.label,
-      STYLE.tracks.textPadding + shiftRight,
-      STYLE.tracks.textPadding,
-      { textBaseline: "top", boxStyle: {} },
-    );
   }
 
   syncDimensions() {

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -48,9 +48,8 @@ export class CanvasTrack extends ShadowBaseElement {
   protected _scaleFactor: number;
   protected trackContainer: HTMLDivElement;
   protected defaultTrackHeight: number;
-  private currentHeight: number;
-
-  private expander: Expander;
+  protected collapsedTrackHeight: number;
+  protected currentHeight: number;
 
   hoverTargets: HoverBox[];
   isInitialized: boolean = false;
@@ -58,25 +57,15 @@ export class CanvasTrack extends ShadowBaseElement {
 
   onElementClick: (element: RenderBand | RenderDot) => void | null;
 
-  isExpanded(): boolean {
-    return this.expander.isExpanded;
-  }
-
   constructor(id: string, label: string, defaultHeight: number) {
     super(template);
 
     this.id = id;
     this.label = label;
     this.defaultTrackHeight = defaultHeight;
+    this.collapsedTrackHeight = 20;
   }
 
-  setExpandedHeight(height: number) {
-    this.expander.expandedHeight = height;
-    if (this.expander.isExpanded) {
-      this.currentHeight = height;
-      this.syncDimensions();
-    }
-  }
 
   getNtsPerPixel(xRange: Rng) {
     const nNts = xRange[1] - xRange[0];
@@ -118,24 +107,6 @@ export class CanvasTrack extends ShadowBaseElement {
   // can all be rendered as such: canvas.render(updateData);
   async render(_updateData: boolean) {}
 
-  initializeExpander(
-    eventKey: string,
-    startExpanded: boolean,
-    onExpand: () => void,
-  ) {
-    this.expander = new Expander(startExpanded);
-    const height = this.defaultTrackHeight;
-
-    this.trackContainer.addEventListener(eventKey, (event) => {
-      event.preventDefault();
-      this.expander.toggle();
-      this.currentHeight = this.expander.isExpanded
-        ? this.expander.expandedHeight
-        : height;
-      this.syncDimensions();
-      onExpand();
-    });
-  }
 
   initializeClick(onElementClick: (el: HoverBox) => void | null = null) {
     getCanvasClick(this.canvas, () => this.hoverTargets, onElementClick);
@@ -203,22 +174,6 @@ export class CanvasTrack extends ShadowBaseElement {
       width: displayWidth,
       height: displayHeight,
     };
-  }
-}
-
-class Expander {
-  expandedHeight: number = null;
-  isExpanded: boolean;
-
-  constructor(isExpanded: boolean) {
-    this.isExpanded = isExpanded;
-  }
-
-  toggle() {
-    this.isExpanded = !this.isExpanded;
-    if (this.isExpanded && this.expandedHeight == null) {
-      console.error("Need to assign an expanded height");
-    }
   }
 }
 

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -1,11 +1,8 @@
-import { STYLE } from "../../../constants";
 import { renderBackground } from "../../../draw/render_utils";
 import { drawLabel } from "../../../draw/shapes";
-import { Tooltip } from "../../../util/tooltip_utils";
-
 import { ShadowBaseElement } from "../../util/shadowbaseelement";
-import { eventInBox } from "../../../util/utils";
 import { setupCanvasClick, getCanvasHover } from "../../util/canvas_interaction";
+import { STYLE } from "../../../constants";
 
 // FIXME: Move somewhere
 const PADDING_SIDES = 0;
@@ -63,7 +60,7 @@ export class CanvasTrack extends ShadowBaseElement {
     this.id = id;
     this.label = label;
     this.defaultTrackHeight = defaultHeight;
-    this.collapsedTrackHeight = 20;
+    this.collapsedTrackHeight = STYLE.tracks.trackHeight.extraThin;
   }
 
 

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -93,6 +93,9 @@ export class CanvasTrack extends ShadowBaseElement {
   }
 
   renderLoading() {
+    if (this.ctx == null) {
+      throw Error(`${this.label}: Track cannot be rendered before initialized`)
+    }
     renderBackground(this.ctx, this.dimensions);
     drawLabel(
       this.ctx,

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -5,7 +5,7 @@ import { Tooltip } from "../../../util/tooltip_utils";
 
 import { ShadowBaseElement } from "../../util/shadowbaseelement";
 import { eventInBox } from "../../../util/utils";
-import { getCanvasClick, getCanvasHover } from "../../util/canvas_interaction";
+import { setupCanvasClick, getCanvasHover } from "../../util/canvas_interaction";
 
 // FIXME: Move somewhere
 const PADDING_SIDES = 0;
@@ -112,33 +112,11 @@ export class CanvasTrack extends ShadowBaseElement {
 
 
   initializeClick(onElementClick: (el: HoverBox) => void | null = null) {
-    getCanvasClick(this.canvas, () => this.hoverTargets, onElementClick);
+    setupCanvasClick(this.canvas, () => this.hoverTargets, onElementClick);
   }
 
   initializeHoverTooltip() {
     getCanvasHover(this.canvas, () => this.hoverTargets, { showTooltip: true });
-
-    // const tooltip = new Tooltip(document.body);
-    // this.canvas.addEventListener("mousemove", (event) => {
-    //   if (this.hoverTargets == null) {
-    //     return;
-    //   }
-    //   tooltip.onMouseMove(this.canvas, event.offsetX, event.offsetY);
-
-    //   const hovered = this.hoverTargets.find((target) =>
-    //     eventInBox(event, target.box),
-    //   );
-
-    //   if (hovered) {
-    //     tooltip.tooltipEl.textContent = hovered.label;
-    //     tooltip.onMouseMove(this.canvas, event.offsetX, event.offsetY);
-    //   } else {
-    //     tooltip.onMouseLeave();
-    //   }
-    // });
-    // this.canvas.addEventListener("mouseleave", () => {
-    //   tooltip.onMouseLeave();
-    // });
   }
 
   setHoverTargets(hoverTargets: HoverBox[]) {

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -33,7 +33,7 @@ export class DataTrack extends CanvasTrack {
   dragCallbacks: DragCallbacks;
   openTrackContextMenu: (track: DataTrack) => void;
 
-  isHidden: boolean = false;
+  private isHidden: boolean = false;
   private isCollapsed: boolean = false;
   private expander: Expander;
   private labelBox: Box;
@@ -49,6 +49,19 @@ export class DataTrack extends CanvasTrack {
 
   getIsCollapsed(): boolean {
     return this.isCollapsed;
+  }
+
+  toggleHidden() {
+    this.isHidden = !this.isHidden;
+    if (this.isHidden) {
+      this.trackContainer.style.display = "none";
+    } else {
+      this.trackContainer.style.display = "block";
+    }
+  }
+
+  getIsHidden() {
+    return this.isHidden;
   }
 
   toggleCollapsed() {

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -33,6 +33,8 @@ export class DataTrack extends CanvasTrack {
   dragCallbacks: DragCallbacks;
   openTrackContextMenu: (track: DataTrack) => void;
 
+  isHidden: boolean = false;
+
   renderData: BandTrackData | DotTrackData | null;
   getRenderData: () => Promise<BandTrackData | DotTrackData>;
 

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -36,7 +36,6 @@ export class DataTrack extends CanvasTrack {
   private isHidden: boolean = false;
   private isCollapsed: boolean = false;
   private expander: Expander;
-  private labelBox: Box;
 
   renderData: BandTrackData | DotTrackData | null;
   getRenderData: () => Promise<BandTrackData | DotTrackData>;
@@ -53,6 +52,7 @@ export class DataTrack extends CanvasTrack {
 
   toggleHidden() {
     this.isHidden = !this.isHidden;
+    // FIXME: Consider using a CSS class for this
     if (this.isHidden) {
       this.trackContainer.style.display = "none";
     } else {
@@ -280,6 +280,7 @@ export class DataTrack extends CanvasTrack {
   }
 }
 
+// FIXME: Consider what to do with this one. Remove? General height controller?
 class Expander {
   expandedHeight: number = null;
   isExpanded: boolean;

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -112,7 +112,8 @@ export class DataTrack extends CanvasTrack {
     super.initialize();
 
     if (this.dragCallbacks != null) {
-      this.setupDrag();
+      // FIXME: Look over this, how to make the dragging "feel" neat
+      // this.setupDrag();
     }
   }
 

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -34,6 +34,7 @@ export class DataTrack extends CanvasTrack {
   openTrackContextMenu: (track: DataTrack) => void;
 
   isHidden: boolean = false;
+  isCollapsed: boolean = false;
 
   renderData: BandTrackData | DotTrackData | null;
   getRenderData: () => Promise<BandTrackData | DotTrackData>;

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -171,7 +171,6 @@ export class DataTrack extends CanvasTrack {
       label: this.label,
       box,
     };
-    getCanvasHover(this.canvas, () => [hoverBox], { showTooltip: true });
     getCanvasClick(this.canvas, () => [hoverBox], onClick);
   }
 
@@ -189,7 +188,6 @@ export class DataTrack extends CanvasTrack {
   }
 
   drawTrackLabel(shiftRight: number = 0): Box {
-    console.log("Drawing label", this.label);
     return drawLabel(
       this.ctx,
       this.label,

--- a/assets/js/components/tracks/dot_track.ts
+++ b/assets/js/components/tracks/dot_track.ts
@@ -45,8 +45,6 @@ export class DotTrack extends DataTrack {
 
   draw() {
 
-    console.log("Child draw");
-
     super.drawStart();
 
     const { dots } = this.renderData as DotTrackData;
@@ -58,8 +56,6 @@ export class DotTrack extends DataTrack {
     const dotsInRange = dots.filter(
       (dot) => dot.x >= xRange[0] && dot.y <= xRange[1],
     );
-
-    console.log(dotsInRange);
 
     drawDotsScaled(this.ctx, dotsInRange, xScale, yScale);
 

--- a/assets/js/components/tracks/dot_track.ts
+++ b/assets/js/components/tracks/dot_track.ts
@@ -13,6 +13,7 @@ export class DotTrack extends DataTrack {
     yAxis: Axis,
     getRenderData: () => Promise<DotTrackData>,
     dragCallbacks: DragCallbacks,
+    openTrackContextMenu: (track: DataTrack) => void,
   ) {
     super(
       id,
@@ -28,6 +29,7 @@ export class DotTrack extends DataTrack {
         return xScale;
       },
       dragCallbacks,
+      openTrackContextMenu,
       { defaultHeight: trackHeight, dragSelect: true, yAxis },
     );
     this.startExpanded = startExpanded;
@@ -42,7 +44,10 @@ export class DotTrack extends DataTrack {
   }
 
   draw() {
-    super.draw();
+
+    console.log("Child draw");
+
+    super.drawStart();
 
     const { dots } = this.renderData as DotTrackData;
 
@@ -54,10 +59,11 @@ export class DotTrack extends DataTrack {
       (dot) => dot.x >= xRange[0] && dot.y <= xRange[1],
     );
 
-    const yAxisWidth = STYLE.yAxis.width;
+    console.log(dotsInRange);
 
     drawDotsScaled(this.ctx, dotsInRange, xScale, yScale);
-    this.drawTrackLabel(yAxisWidth);
+
+    super.drawEnd();
   }
 }
 

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -71,16 +71,16 @@ export class OverviewTrack extends CanvasTrack {
     this.trackContainer.style.cursor = "pointer";
   }
 
-  async render(_updateData: boolean) {
+  async render(updateData: boolean) {
 
     // FIXME: This one is a bit tricky isn't it
     // We want it to render not on new data, but on resize
     // Do I have all info I need here?
     // Should the renderData be more granular?
     let newRender = false;
-    if (this.renderData == null) {
+    if (this.renderData == null || updateData) {
+      newRender = this.renderData == null;
       this.renderData = await this.getRenderData();
-      newRender = true;
     }
 
     const { xRange, chromosome, dotsPerChrom } = this.renderData;

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -362,8 +362,7 @@ export class TracksManager extends ShadowBaseElement {
   }
 }
 
-function getButton(text: string, onClick: () => void): HTMLDivElement {
-  const row = getContainer("row");
+export function getButton(text: string, onClick: () => void): HTMLDivElement {
   const button = document.createElement("div") as HTMLDivElement;
   button.innerHTML = text;
   button.style.cursor = "pointer";
@@ -371,8 +370,7 @@ function getButton(text: string, onClick: () => void): HTMLDivElement {
   button.onclick = onClick;
   button.style.padding = "4px 8px";
   button.style.borderRadius = "4px";
-  row.appendChild(button);
-  return row;
+  return button;
 }
 
 customElements.define("gens-tracks", TracksManager);

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -18,7 +18,7 @@ import {
 } from "./util/menu_content_utils";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 import { generateID } from "../util/utils";
-import { getContainer } from "./util/menu_utils";
+import { getSimpleButton, getContainer } from "./util/menu_utils";
 import { DataTrack } from "./tracks/base_tracks/data_track";
 
 const COV_Y_RANGE: [number, number] = [-4, 4];
@@ -107,15 +107,15 @@ export class TracksManager extends ShadowBaseElement {
       const buttonRow = getContainer("row")
       buttonRow.style.justifyContent = "left";
 
-      buttonRow.appendChild(getButton("Show", () => {
+      buttonRow.appendChild(getSimpleButton("Show", () => {
         this.showTrack(track.id);
       }));
 
-      buttonRow.appendChild(getButton("Hide", () => {
+      buttonRow.appendChild(getSimpleButton("Hide", () => {
         this.hideTrack(track.id);
       }));
-      buttonRow.appendChild(getButton("Move up", () => {}));
-      buttonRow.appendChild(getButton("Move down", () => {}));
+      buttonRow.appendChild(getSimpleButton("Move up", () => {}));
+      buttonRow.appendChild(getSimpleButton("Move down", () => {}));
 
       openContextMenu(track.label, [
         buttonRow,
@@ -174,7 +174,7 @@ export class TracksManager extends ShadowBaseElement {
           const details = await getVariantDetails(sampleId, variantId);
           const scoutUrl = getVariantURL(variantId);
 
-          const button = getButton("Set highlight", () => {
+          const button = getSimpleButton("Set highlight", () => {
             const id = generateID();
             highlightCallbacks.addHighlight(id, [
               details.position,
@@ -213,7 +213,7 @@ export class TracksManager extends ShadowBaseElement {
       },
       async (id) => {
         const details = await getTranscriptDetails(id);
-        const button = getButton("Set highlight", () => {
+        const button = getSimpleButton("Set highlight", () => {
           const id = generateID();
           highlightCallbacks.addHighlight(id, [details.start, details.end]);
         });
@@ -254,7 +254,7 @@ export class TracksManager extends ShadowBaseElement {
 
         const openContextMenuId = async (id: string) => {
           const details = await getAnnotationDetails(id);
-          const button = getButton("Set highlight", () => {
+          const button = getSimpleButton("Set highlight", () => {
             const id = generateID();
             highlightCallbacks.addHighlight(id, [details.start, details.end]);
           });
@@ -360,17 +360,6 @@ export class TracksManager extends ShadowBaseElement {
       track.render(updateData);
     }
   }
-}
-
-export function getButton(text: string, onClick: () => void): HTMLDivElement {
-  const button = document.createElement("div") as HTMLDivElement;
-  button.innerHTML = text;
-  button.style.cursor = "pointer";
-  button.style.border = "1px solid #ccc";
-  button.onclick = onClick;
-  button.style.padding = "4px 8px";
-  button.style.borderRadius = "4px";
-  return button;
 }
 
 customElements.define("gens-tracks", TracksManager);

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -28,7 +28,7 @@ const BAF_Y_RANGE: [number, number] = [0, 1];
 const COV_Y_TICKS = [-3, -2, -1, 0, 1, 2, 3];
 const BAF_Y_TICKS = [0.2, 0.4, 0.6, 0.8];
 
-const trackHeight = STYLE.bandTrack.trackHeight;
+const trackHeight = STYLE.tracks.trackHeight;
 
 // FIXME: This will need to be generalized such that tracks aren't hard-coded
 const template = document.createElement("template");
@@ -72,7 +72,7 @@ export class TracksManager extends ShadowBaseElement {
   overviewTracks: OverviewTrack[];
   dataTracks: DataTrack[] = [];
 
-  // Remove this one or?
+  // FIXME: Remove this one or?
   annotationTracks: DataTrack[] = [];
   getXRange: () => Rng;
 
@@ -83,7 +83,6 @@ export class TracksManager extends ShadowBaseElement {
   getAnnotationDetails: (id: string) => Promise<ApiAnnotationDetails>;
   openContextMenu: (header: string, content: HTMLElement[]) => void;
   openTrackContextMenu: (track: DataTrack) => void;
-  // makeNewAnnotTrack: (id: string, label: string) => DataTrack;
 
   constructor() {
     super(template);

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -19,6 +19,7 @@ import {
 import { ShadowBaseElement } from "./util/shadowbaseelement";
 import { generateID } from "../util/utils";
 import { getContainer } from "./util/menu_utils";
+import { DataTrack } from "./tracks/base_tracks/data_track";
 
 const COV_Y_RANGE: [number, number] = [-4, 4];
 const BAF_Y_RANGE: [number, number] = [0, 1];
@@ -101,7 +102,14 @@ export class TracksManager extends ShadowBaseElement {
       removeHighlight: highlightCallbacks.removeHighlight,
     };
 
+    const openTrackContextMenu = (track: DataTrack) => {
+      const body = document.createElement("div");
+      body.innerHTML = "Some body is here";
+      openContextMenu(track.label, [body]);
+    }
+
     const covTracks = [];
+    const bafTracks = [];
     const variantTracks = [];
 
     for (const sampleId of sampleIds) {
@@ -122,6 +130,7 @@ export class TracksManager extends ShadowBaseElement {
           };
         },
         dragCallbacks,
+        openTrackContextMenu,
       );
       const bafTrack = new DotTrack(
         `${sampleId}_baf`,
@@ -136,6 +145,7 @@ export class TracksManager extends ShadowBaseElement {
           };
         },
         dragCallbacks,
+        openTrackContextMenu,
       );
       const variantTrack = new BandTrack(
         `${sampleId}_variants`,
@@ -163,9 +173,11 @@ export class TracksManager extends ShadowBaseElement {
           openContextMenu("Variant", content);
         },
         dragCallbacks,
+        openTrackContextMenu,
       );
 
-      covTracks.push(coverageTrack, bafTrack);
+      covTracks.push(coverageTrack);
+      bafTracks.push(bafTrack);
       variantTracks.push(variantTrack);
     }
 
@@ -192,6 +204,7 @@ export class TracksManager extends ShadowBaseElement {
         openContextMenu("Transcript", content);
       },
       dragCallbacks,
+      openTrackContextMenu,
     );
     const ideogramTrack = new IdeogramTrack(
       "ideogram",
@@ -240,6 +253,7 @@ export class TracksManager extends ShadowBaseElement {
             getAnnotTrackData(sourceId, getXRange, dataSource.getAnnotation),
           openContextMenuId,
           dragCallbacks,
+          openTrackContextMenu,
         );
         return track;
       },
@@ -282,6 +296,7 @@ export class TracksManager extends ShadowBaseElement {
     this.tracks.push(
       ideogramTrack,
       ...covTracks,
+      ...bafTracks,
       ...variantTracks,
       annotationTracks,
       genesTrack,

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -17,7 +17,7 @@ import {
   getVariantContextMenuContent,
 } from "./util/menu_content_utils";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
-import { generateID } from "../util/utils";
+import { generateID, moveElement } from "../util/utils";
 import { getSimpleButton, getContainer } from "./util/menu_utils";
 import { DataTrack } from "./tracks/base_tracks/data_track";
 
@@ -104,22 +104,24 @@ export class TracksManager extends ShadowBaseElement {
     };
 
     const openTrackContextMenu = (track: DataTrack) => {
-      const buttonRow = getContainer("row")
+      const buttonRow = getContainer("row");
       buttonRow.style.justifyContent = "left";
 
-      buttonRow.appendChild(getSimpleButton("Show", () => {
-        this.showTrack(track.id);
-      }));
+      buttonRow.appendChild(
+        getSimpleButton("Show", () => {
+          this.showTrack(track.id);
+        }),
+      );
 
-      buttonRow.appendChild(getSimpleButton("Hide", () => {
-        this.hideTrack(track.id);
-      }));
+      buttonRow.appendChild(
+        getSimpleButton("Hide", () => {
+          this.hideTrack(track.id);
+        }),
+      );
       buttonRow.appendChild(getSimpleButton("Move up", () => {}));
       buttonRow.appendChild(getSimpleButton("Move down", () => {}));
 
-      openContextMenu(track.label, [
-        buttonRow,
-      ]);
+      openContextMenu(track.label, [buttonRow]);
     };
 
     const covTracks = [];
@@ -342,18 +344,32 @@ export class TracksManager extends ShadowBaseElement {
     console.error("Did not find any track with ID", trackId);
   }
 
+  moveTrack(trackId: string, direction: "up" | "down") {
+    const track = this.getTrackById(trackId);
+    const trackIndex = this.tracks.indexOf(track);
+    const shift = direction == "up" ? -1 : 1;
+
+    const container = track.parentNode;
+    if (direction == "up") {
+      container.insertBefore(track, this.tracks[trackIndex-1]);
+    } else {
+      container.insertBefore(track, this.tracks[trackIndex + 1].nextSibling)
+    }
+
+    moveElement(this.tracks, trackIndex, shift, true);
+  }
+
   showTrack(trackId: string) {
     const track = this.getTrackById(trackId);
-    this.parentContainer.appendChild(track)
+    this.parentContainer.appendChild(track);
   }
 
   hideTrack(trackId: string) {
     const track = this.getTrackById(trackId);
-    this.parentContainer.removeChild(track)
+    this.parentContainer.removeChild(track);
   }
 
   render(updateData: boolean) {
-
     // FIXME: React to whether tracks are not present
 
     for (const track of this.tracks) {

--- a/assets/js/components/util/canvas_interaction.ts
+++ b/assets/js/components/util/canvas_interaction.ts
@@ -5,13 +5,12 @@ interface HoverSettings {
   showTooltip: boolean;
 }
 
-export function getCanvasClick(
+export function setupCanvasClick(
   canvas: HTMLCanvasElement,
   getHoverTargets: () => HoverBox[],
   onElementClick: (el: HoverBox) => void | null = null,
 ) {
   canvas.addEventListener("click", (event) => {
-
     const hoverTargets = getHoverTargets();
 
     if (!hoverTargets || !onElementClick) {
@@ -26,20 +25,22 @@ export function getCanvasClick(
       onElementClick(hoveredTarget);
     }
   });
+}
 
+export function setCanvasPointerCursor(
+  canvas: HTMLCanvasElement,
+  getHoverTargets: () => HoverBox[],
+) {
   canvas.addEventListener("mousemove", (event) => {
-
     const hoverTargets = getHoverTargets();
 
     if (!hoverTargets) {
       return;
     }
-    const hovered = hoverTargets.find((target) =>
+    const hovered = hoverTargets.some((target) =>
       eventInBox(event, target.box),
     );
-    if (onElementClick) {
-      canvas.style.cursor = hovered ? "pointer" : "default";
-    }
+    canvas.style.cursor = hovered ? "pointer" : "auto";
   });
 }
 
@@ -51,7 +52,6 @@ export function getCanvasHover(
   const tooltip = settings.showTooltip ? new Tooltip(document.body) : null;
 
   canvas.addEventListener("mousemove", (event) => {
-
     const hoverTargets = getHoverTargets();
 
     if (hoverTargets == null) {

--- a/assets/js/components/util/canvas_interaction.ts
+++ b/assets/js/components/util/canvas_interaction.ts
@@ -1,0 +1,82 @@
+import { Tooltip } from "../../util/tooltip_utils";
+import { eventInBox } from "../../util/utils";
+
+interface HoverSettings {
+  showTooltip: boolean;
+}
+
+export function getCanvasClick(
+  canvas: HTMLCanvasElement,
+  getHoverTargets: () => HoverBox[],
+  onElementClick: (el: HoverBox) => void | null = null,
+) {
+  canvas.addEventListener("click", (event) => {
+
+    const hoverTargets = getHoverTargets();
+
+    if (!hoverTargets || !onElementClick) {
+      return;
+    }
+
+    const hoveredTarget = hoverTargets.find((target) =>
+      eventInBox(event, target.box),
+    );
+
+    if (hoveredTarget && onElementClick) {
+      onElementClick(hoveredTarget);
+    }
+  });
+
+  canvas.addEventListener("mousemove", (event) => {
+
+    const hoverTargets = getHoverTargets();
+
+    if (!hoverTargets) {
+      return;
+    }
+    const hovered = hoverTargets.find((target) =>
+      eventInBox(event, target.box),
+    );
+    if (onElementClick) {
+      canvas.style.cursor = hovered ? "pointer" : "default";
+    }
+  });
+}
+
+export function getCanvasHover(
+  canvas: HTMLCanvasElement,
+  getHoverTargets: () => HoverBox[],
+  settings: HoverSettings,
+) {
+  const tooltip = settings.showTooltip ? new Tooltip(document.body) : null;
+
+  canvas.addEventListener("mousemove", (event) => {
+
+    const hoverTargets = getHoverTargets();
+
+    if (hoverTargets == null) {
+      return;
+    }
+    if (tooltip != null) {
+      tooltip.onMouseMove(canvas, event.offsetX, event.offsetY);
+    }
+
+    const hovered = hoverTargets.find((target) =>
+      eventInBox(event, target.box),
+    );
+
+    if (tooltip != null) {
+      if (hovered) {
+        tooltip.tooltipEl.textContent = hovered.label;
+        tooltip.onMouseMove(canvas, event.offsetX, event.offsetY);
+      } else {
+        tooltip.onMouseLeave();
+      }
+    }
+  });
+  canvas.addEventListener("mouseleave", () => {
+    if (tooltip != null) {
+      tooltip.onMouseLeave();
+    }
+  });
+}

--- a/assets/js/components/util/menu_utils.ts
+++ b/assets/js/components/util/menu_utils.ts
@@ -11,7 +11,29 @@ export function getAHref(label: string, href: string): HTMLAnchorElement {
   return a;
 }
 
+export function getSimpleButton(text: string, onClick: () => void): HTMLDivElement {
+  const button = document.createElement("div") as HTMLDivElement;
 
+  button.innerHTML = text;
+  button.style.cursor = "pointer";
+  button.style.border = "1px solid #ccc";
+  button.onclick = onClick;
+  button.style.padding = "4px 8px";
+  button.style.borderRadius = "4px";
+  return button;
+}
+
+export function getIconButton(icon: string, title: string, onClick: () => void): HTMLDivElement {
+  // const button = document.createElement("div") as HTMLDivElement;
+  const button = getSimpleButton("", onClick);
+  button.title = title;
+
+  const iconElem = document.createElement("span") as HTMLSpanElement;
+  iconElem.classList = `fas ${icon}`
+  button.appendChild(iconElem);
+  
+  return button;
+}
 
 export function getURLRow(text: string) {
 

--- a/assets/js/components/util/menu_utils.ts
+++ b/assets/js/components/util/menu_utils.ts
@@ -27,6 +27,7 @@ export function getIconButton(icon: string, title: string, onClick: () => void):
   // const button = document.createElement("div") as HTMLDivElement;
   const button = getSimpleButton("", onClick);
   button.title = title;
+  button.className = "icon-button";
 
   const iconElem = document.createElement("span") as HTMLSpanElement;
   iconElem.classList = `fas ${icon}`

--- a/assets/js/components/util/menu_utils.ts
+++ b/assets/js/components/util/menu_utils.ts
@@ -24,7 +24,6 @@ export function getSimpleButton(text: string, onClick: () => void): HTMLDivEleme
 }
 
 export function getIconButton(icon: string, title: string, onClick: () => void): HTMLDivElement {
-  // const button = document.createElement("div") as HTMLDivElement;
   const button = getSimpleButton("", onClick);
   button.title = title;
   button.className = "icon-button";

--- a/assets/js/components/util/popup.ts
+++ b/assets/js/components/util/popup.ts
@@ -1,4 +1,4 @@
-import { PAD, STYLE } from "../../constants";
+import { SIZES, STYLE } from "../../constants";
 import { getEntry } from "./menu_utils";
 import { ShadowBaseElement } from "./shadowbaseelement";
 
@@ -29,7 +29,7 @@ template.innerHTML = String.raw`
     #entries {
       display: flex;
       flex-direction: column;
-      gap: ${PAD.l}px;
+      gap: ${SIZES.l}px;
     }
 
     #container {

--- a/assets/js/constants.ts
+++ b/assets/js/constants.ts
@@ -16,6 +16,15 @@ export const FONT_WEIGHT = {
   bold: 300,
 }
 
+export const ICONS = {
+  up: "fa-arrow-up",
+  down: "fa-arrow-down",
+  show: "fa-eye",
+  hide: "fa-eye-slash",
+  minimize: "fa-minimize",
+  maximize: "fa-maximize",
+}
+
 export const COLORS = {
   white: "#FFF",
   black: "#222",
@@ -32,7 +41,7 @@ export const COLORS = {
   transparentBlue: "#55667744",
 };
 
-export const PAD = {
+export const SIZES = {
   xxs: 2,
   xs: 4,
   s: 6,
@@ -51,10 +60,10 @@ export const STYLE = {
     textColor: COLORS.black,
     closeColor: COLORS.darkGray,
     borderWidth: 1,
-    padding: PAD.l,
+    padding: SIZES.l,
     font,
     borderRadius: 6,
-    margin: PAD.s,
+    margin: SIZES.s,
     headerSize: FONT_SIZE.large,
     headerFontWeight: FONT_WEIGHT.header,
     breadFontWeight: FONT_WEIGHT.bold,
@@ -69,18 +78,13 @@ export const STYLE = {
     default: "gray",
   },
   bandTrack: {
-    trackPadding: PAD.l,
-    bandPadding: PAD.xxs,
-    trackHeight: {
-      extraThin: 20,
-      thin: 45,
-      thick: 80,
-    },
+    trackPadding: SIZES.l,
+    bandPadding: SIZES.xxs,
     edgeColor: COLORS.darkGray,
     minBandWidth: 2,
   },
   ideogramMarker: {
-    leftMargin: PAD.xs,
+    leftMargin: SIZES.xs,
     borderWidth: 2,
   },
   bands: {
@@ -89,7 +93,7 @@ export const STYLE = {
   },
   overviewTrack: {
     titleSpace: 20,
-    labelPad: PAD.s
+    labelPad: SIZES.s
   },
   tracks: {
     // edgeColor: colors.white,
@@ -105,17 +109,22 @@ export const STYLE = {
     },
     font,
     textColor: COLORS.darkGray,
-    textPadding: PAD.xs,
-    textFramePadding: PAD.xxs,
+    textPadding: SIZES.xs,
+    textFramePadding: SIZES.xxs,
     textLaneSize: 20,
     backgroundColor: COLORS.white,
     frameLineWidth: 2,
+    trackHeight: {
+      extraThin: 20,
+      thin: 45,
+      thick: 80,
+    },
   },
   ideogramTrack: {
     endBevelProportion: 0.05,
     centromereIndentProportion: 0.3,
-    xPad: PAD.m,
-    yPad: PAD.xs,
+    xPad: SIZES.m,
+    yPad: SIZES.xs,
     lineColor: COLORS.darkGray,
     lineWidth: 1,
     stainToColor: {

--- a/assets/js/draw/shapes.ts
+++ b/assets/js/draw/shapes.ts
@@ -125,9 +125,8 @@ export function drawLabel(
   leftX: number,
   topY: number,
   style: LabelStyle = {},
-) {
+): Box {
   const {
-    withFrame = true,
     textBaseline = "top",
     padding = STYLE.tracks.textFramePadding,
     font = STYLE.tracks.font,
@@ -139,32 +138,32 @@ export function drawLabel(
   ctx.font = font;
 
   const metrics = ctx.measureText(label);
-  const textWidth = metrics.width;
+  const textWidth: number = metrics.width;
   const textHeight =
     metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
 
-  if (withFrame) {
-    const x1 = leftX - padding;
-    const frameWidth = textWidth + 2 * padding;
-    const y1 = topY - padding;
-    const frameHeight = textHeight + 2 * padding;
+  const x1 = leftX - padding;
+  const frameWidth = textWidth + 2 * padding;
+  const y1 = topY - padding;
+  const frameHeight = textHeight + 2 * padding;
 
-    const box = {
-      x1,
-      x2: x1 + frameWidth,
-      y1,
-      y2: y1 + frameHeight,
-    };
+  const box: Box = {
+    x1,
+    x2: x1 + frameWidth,
+    y1,
+    y2: y1 + frameHeight,
+  };
 
-    if (boxStyle != undefined) {
-      drawBox(ctx, box, boxStyle);
-    }
+  if (boxStyle != undefined) {
+    drawBox(ctx, box, boxStyle);
   }
 
   ctx.fillStyle = textColor;
   ctx.textAlign = textAlign;
   ctx.textBaseline = textBaseline;
   ctx.fillText(label, leftX, topY);
+
+  return box;
 }
 
 export function drawBox(

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -92,9 +92,14 @@ export async function initCanvases({
     });
 
   const settingsPage = document.createElement("settings-page") as SettingsPage;
-  settingsPage.setSources(annotSources, defaultAnnot, (_newSources) => {
-    gensTracks.render(true);
-  });
+  settingsPage.setSources(
+    annotSources,
+    defaultAnnot,
+    (_newSources) => {
+      gensTracks.render(true);
+    },
+    () => gensTracks.getDataTracks(),
+  );
 
   initialize(
     sampleIds,
@@ -192,7 +197,11 @@ async function initialize(
     async (id: string) => await api.getAnnotationDetails(id),
     async (id: string) => await api.getTranscriptDetails(id),
     async (sampleId: string, variantId: string) =>
-      await api.getVariantDetails(sampleId, variantId, inputControls.getRegion().chrom),
+      await api.getVariantDetails(
+        sampleId,
+        variantId,
+        inputControls.getRegion().chrom,
+      ),
     openContextMenu,
     highlightCallbacks,
   );

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -16,6 +16,7 @@ import { CHROMOSOMES } from "./constants";
 import { SideMenu } from "./components/side_menu";
 import { SettingsPage } from "./components/settings_page";
 import { HeaderInfo } from "./components/header_info";
+import { DataTrack } from "./components/tracks/base_tracks/data_track";
 
 export async function initCanvases({
   caseId,
@@ -48,7 +49,6 @@ export async function initCanvases({
 
   const api = new API(caseId, genomeBuild, gensApiURL);
 
-
   const renderDataSource = getRenderDataSource(
     api,
     () => {
@@ -64,7 +64,7 @@ export async function initCanvases({
   const render = (updatedData: boolean) => {
     gensTracks.render(updatedData);
     settingsPage.render();
-  }
+  };
 
   const onChromClick = async (chrom) => {
     const chromData = await api.getChromData(chrom);
@@ -98,8 +98,6 @@ export async function initCanvases({
       };
     });
 
-  
-
   settingsPage.setSources(
     () => render(false),
     annotSources,
@@ -108,9 +106,9 @@ export async function initCanvases({
       render(true);
     },
     () => gensTracks.getDataTracks(),
+    (trackId: string, direction: "up" | "down") =>
+      gensTracks.moveTrack(trackId, direction),
   );
-
-
 
   initialize(
     render,

--- a/assets/js/util/collections.ts
+++ b/assets/js/util/collections.ts
@@ -1,0 +1,31 @@
+export function moveElement<T>(
+  orig: T[],
+  pos: number,
+  shift: number,
+  inPlace: boolean,
+): T[] {
+  let target;
+  if (inPlace) {
+    target = orig;
+  } else {
+    target = [...orig];
+  }
+  const el = target.splice(pos, 1)[0];
+  const newPos = pos + shift;
+  target.splice(newPos, 0, el);
+
+  return target;
+}
+
+/**
+ * Retrieve elements only present in arr1
+ * Optionally provide a function to extract the value (V) to compare
+ */
+export function diff<T,V>(arr1: T[], arr2: T[], idFn?: (T) => V): T[] {
+  if (idFn == null) {
+    return arr1.filter((value) => !arr2.includes(value));
+  } else {
+    const arr2Ids = arr2.map((value) => idFn(value));
+    return arr1.filter((value) => !arr2Ids.includes(idFn(value)));
+  }
+}

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -244,7 +244,6 @@ export function moveElement<T>(
   shift: number,
   inPlace: boolean,
 ): T[] {
-  console.log("Moving", orig);
   let target;
   if (inPlace) {
     target = orig;
@@ -255,6 +254,5 @@ export function moveElement<T>(
   const newPos = pos + shift;
   target.splice(newPos, 0, el);
 
-  console.log("Results", target);
   return target;
 }

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -238,21 +238,3 @@ export function generateID() {
   return `${ts}-${rand64}`;
 }
 
-export function moveElement<T>(
-  orig: T[],
-  pos: number,
-  shift: number,
-  inPlace: boolean,
-): T[] {
-  let target;
-  if (inPlace) {
-    target = orig;
-  } else {
-    target = [...orig];
-  }
-  const el = target.splice(pos, 1)[0];
-  const newPos = pos + shift;
-  target.splice(newPos, 0, el);
-
-  return target;
-}

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -232,8 +232,29 @@ export function generateID() {
   const randBuf = crypto.getRandomValues(new Uint32Array(2));
   // build a 64-bit BigInt without any `n` literals
   const shift32 = BigInt(32);
-  const high   = BigInt(randBuf[0]) << shift32;
-  const low    = BigInt(randBuf[1]);
+  const high = BigInt(randBuf[0]) << shift32;
+  const low = BigInt(randBuf[1]);
   const rand64 = (high | low).toString(36);
   return `${ts}-${rand64}`;
+}
+
+export function moveElement<T>(
+  orig: T[],
+  pos: number,
+  shift: number,
+  inPlace: boolean,
+): T[] {
+  console.log("Moving", orig);
+  let target;
+  if (inPlace) {
+    target = orig;
+  } else {
+    target = [...orig];
+  }
+  const el = target.splice(pos, 1)[0];
+  const newPos = pos + shift;
+  target.splice(newPos, 0, el);
+
+  console.log("Results", target);
+  return target;
 }


### PR DESCRIPTION
Close #345

Adds a panel in the settings page allowing the user to control showing, hiding, moving, collapsing tracks.

For now buttons for everything. Usability could be improved ahead by drag-and-drop etc.

Also adds a track menu (yet to be made functional).

Many fixme's left. The changes were growing and seemed to me I needed to wrap something intermediary here.

![show_hide_collapse_move](https://github.com/user-attachments/assets/deaf5bae-224f-4655-b364-6546f6f2e98d)
