### PR TITLE
Tracks menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - View multiple coverage tracks for samples within a case.
  - Renderings are debounced and keep track of the last render such that they not double-render
  - Tracks can be shown / hidden, collapsed and moved
- - Tracks menu and customize Y-axis and colors for dot tracks
+ - Tracks menu and customize Y-axis
 
 ### Changed
  - Resolution increased 2x for tracks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - View multiple coverage tracks for samples within a case.
  - Renderings are debounced and keep track of the last render such that they not double-render
  - Tracks can be shown / hidden, collapsed and moved
+ - Tracks menu and customize Y-axis and colors for dot tracks
 
 ### Changed
  - Resolution increased 2x for tracks.

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -1,14 +1,13 @@
-import { STYLE } from "../../../constants";
+import { SIZES, STYLE } from "../../../constants";
 import {
   drawYAxis,
   getLinearScale,
   renderBackground,
 } from "../../../draw/render_utils";
 import { drawHorizontalLineInScale, drawLabel } from "../../../draw/shapes";
-import { generateID, generateTicks, rangeSize } from "../../../util/utils";
+import { generateID, generateTicks, getTickSize, rangeSize } from "../../../util/utils";
 import {
   setupCanvasClick,
-  getCanvasHover,
   setCanvasPointerCursor,
 } from "../../util/canvas_interaction";
 import { keyLogger } from "../../util/keylogger";
@@ -27,7 +26,7 @@ interface Settings {
 
 const DEBOUNCE_DELAY = 500;
 
-const Y_PAD = 6;
+const Y_PAD = SIZES.s;
 
 export class DataTrack extends CanvasTrack {
   settings: Settings;
@@ -265,17 +264,7 @@ export class DataTrack extends CanvasTrack {
 
   renderYAxis(yAxis: Axis) {
     const yScale = getLinearScale(yAxis.range, this.getYDim());
-
-    // FIXME: Util function
-    const tickSize =
-      rangeSize(yAxis.range) > 3
-        ? 1
-        : rangeSize(yAxis.range) > 1.5
-          ? 0.5
-          : rangeSize(yAxis.range) > 0.8
-            ? 0.2
-            : 0.1;
-
+    const tickSize = getTickSize(yAxis.range);
     const ticks = generateTicks(yAxis.range, tickSize);
 
     for (const yTick of ticks) {

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -46,6 +46,10 @@ export class DataTrack extends CanvasTrack {
     return this.settings.yAxis;
   }
 
+  updateYAxis(range: Rng) {
+    this.settings.yAxis.range = range;
+  }
+
   isExpanded(): boolean {
     return this.expander.isExpanded;
   }

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -40,7 +40,11 @@ export class DataTrack extends CanvasTrack {
   renderData: BandTrackData | DotTrackData | null;
   getRenderData: () => Promise<BandTrackData | DotTrackData>;
 
-  private _renderSeq = 0;
+  private renderSeq = 0;
+
+  getYAxis(): Axis | null {
+    return this.settings.yAxis;
+  }
 
   isExpanded(): boolean {
     return this.expander.isExpanded;
@@ -175,10 +179,10 @@ export class DataTrack extends CanvasTrack {
     // Only the last request is of interest
     const _fetchData = debounce(
       async () => {
-        this._renderSeq = this._renderSeq + 1;
-        const mySeq = this._renderSeq;
+        this.renderSeq = this.renderSeq + 1;
+        const mySeq = this.renderSeq;
         this.renderData = await this.getRenderData();
-        if (mySeq !== this._renderSeq) {
+        if (mySeq !== this.renderSeq) {
           return;
         }
         this.draw();

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -193,25 +193,33 @@ export class TracksManager extends ShadowBaseElement {
         const startNode = document.createElement("input");
         startNode.type = "number";
         startNode.value = axis.range[0].toString();
-        startNode.step = "0.1"
+        startNode.step = "0.1";
         startNode.style.flex = "1 1 0px";
         startNode.style.minWidth = "0";
         axisRow.appendChild(startNode);
 
-        startNode.addEventListener("change", () => {
-          console.log("New value:", startNode.value);
-        });
 
         const endNode = document.createElement("input");
         endNode.type = "number";
         endNode.value = axis.range[1].toString();
-        endNode.step = "0.1"
+        endNode.step = "0.1";
         endNode.style.flex = "1 1 0px";
         endNode.style.minWidth = "0";
 
-        endNode.addEventListener("change", () => {
-          console.log("New value:", endNode.value);
-        });
+
+        const onRangeChange = () => {
+          const parsedRange: Rng = [
+            parseFloat(startNode.value),
+            parseFloat(endNode.value),
+          ];  
+          track.updateYAxis(parsedRange);
+          this.render(false);
+        }
+
+        startNode.addEventListener("change", onRangeChange);
+
+
+        endNode.addEventListener("change", onRangeChange);
 
         axisRow.appendChild(endNode);
 

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -144,6 +144,7 @@ export class TracksManager extends ShadowBaseElement {
       removeHighlight: highlightCallbacks.removeHighlight,
     };
 
+    // FIXME: Move to util function
     this.openTrackContextMenu = (track: DataTrack) => {
       const buttonsDiv = document.createElement("div");
       buttonsDiv.style.display = "flex";

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -26,7 +26,7 @@ import {
 import { DataTrack } from "./tracks/base_tracks/data_track";
 import { diff, moveElement } from "../util/collections";
 
-const COV_Y_RANGE: [number, number] = [-4, 4];
+const COV_Y_RANGE: [number, number] = [-3, 3];
 const BAF_Y_RANGE: [number, number] = [0, 1];
 
 const COV_Y_TICKS = [-3, -2, -1, 0, 1, 2, 3];
@@ -253,14 +253,14 @@ export class TracksManager extends ShadowBaseElement {
         `${sampleId} cov`,
         sampleId,
         (sampleId: string) => this.dataSource.getCovData(sampleId),
-        { startExpanded, yAxis: { range: COV_Y_RANGE, ticks: COV_Y_TICKS } },
+        { startExpanded, yAxis: { range: COV_Y_RANGE } },
       );
       const bafTrack = this.getDotTrack(
         `${sampleId}_log2_baf`,
         `${sampleId} baf`,
         sampleId,
         (sampleId: string) => this.dataSource.getBafData(sampleId),
-        { startExpanded, yAxis: { range: BAF_Y_RANGE, ticks: BAF_Y_TICKS } },
+        { startExpanded, yAxis: { range: BAF_Y_RANGE } },
       );
 
       const variantTrack = this.getVariantTrack(

--- a/assets/js/components/util/menu_content_utils.ts
+++ b/assets/js/components/util/menu_content_utils.ts
@@ -40,7 +40,7 @@ export function getVariantContextMenuContent(
 
 export function getGenesContextMenuContent(
   id: string,
-  details: ApiTranscriptDetails,
+  details: ApiGeneDetails,
 ): HTMLDivElement[] {
   const info: { key: string; value: string }[] = [
     { key: "Range", value: `${details.start} - ${details.end}` },

--- a/assets/js/components/util/menu_utils.ts
+++ b/assets/js/components/util/menu_utils.ts
@@ -108,9 +108,13 @@ export function getURLRow(text: string) {
   return row;
 }
 
-export function getContainer(type: "row" | "column", text?: string) {
+export function getContainer(direction: "row" | "column", text?: string) {
   const row = document.createElement("div");
-  row.className = `menu-${type}`;
+  row.className = `menu-${direction}`;
+  row.style.display = "flex";
+  row.style.flexDirection = direction;
+  row.style.flexWrap = "nowrap";
+  row.style.whiteSpace = "nowrap";
   if (text != null) {
     row.appendChild(getDiv(text));
   }

--- a/assets/js/draw/render_utils.ts
+++ b/assets/js/draw/render_utils.ts
@@ -4,7 +4,6 @@ import {
   drawBox,
   drawLabel,
   drawLine,
-  drawVerticalLineInScale,
 } from "./shapes";
 
 export function drawYAxis(

--- a/assets/js/draw/render_utils.ts
+++ b/assets/js/draw/render_utils.ts
@@ -1,6 +1,11 @@
 import { rangeSize } from "../util/utils";
-import { STYLE } from "../constants";
-import { drawBox, drawLabel } from "./shapes";
+import { COLORS, STYLE } from "../constants";
+import {
+  drawBox,
+  drawLabel,
+  drawLine,
+  drawVerticalLineInScale,
+} from "./shapes";
 
 export function drawYAxis(
   ctx: CanvasRenderingContext2D,
@@ -9,8 +14,25 @@ export function drawYAxis(
   yRange: Rng,
 ) {
   const style = STYLE.yAxis;
-  const box = { x1: 0, x2: style.width, y1: yScale(yRange[0]), y2: yScale(yRange[1]) };
-  drawBox(ctx, box, { fillColor: style.backgroundColor });
+  const box = {
+    x1: 0,
+    x2: style.width,
+    y1: yScale(yRange[0]),
+    // If not +1, the final tick line is drawn
+    y2: yScale(yRange[1]) + 1,
+  };
+  drawBox(ctx, box, { fillColor: style.backgroundColor, borderColor: COLORS.white });
+  drawLine(
+    ctx,
+    {
+      x1: style.width,
+      x2: style.width,
+      y1: yScale(yRange[0]),
+      y2: yScale(yRange[1]),
+    },
+    { color: style.backgroundColor },
+  );
+  // drawBox(ctx, box, { fillColor: style.backgroundColor });
 
   for (const y of ys) {
     drawLabel(ctx, y.toString(), style.labelPos, yScale(y), {
@@ -21,11 +43,10 @@ export function drawYAxis(
   }
 }
 
-
 export function renderBackground(
   ctx: CanvasRenderingContext2D,
   canvasDim: { height: number; width: number },
-  color: string = STYLE.tracks.edgeColor
+  color: string = STYLE.tracks.edgeColor,
 ) {
   const style = STYLE.tracks;
   ctx.fillStyle = style.backgroundColor;
@@ -40,7 +61,6 @@ export function renderBand(
   band: RenderBand,
   xScale: Scale,
 ) {
-
   const style = STYLE.bands;
 
   ctx.fillStyle = band.color;
@@ -166,7 +186,6 @@ export function rgbArrayToString(rgbArray: number[]): string {
   return `rgb(${rgbArray[0]},${rgbArray[1]},${rgbArray[2]})`;
 }
 
-
 /**
  * Builds a function used to map from domain (i.e. nucleotides)
  * to range (i.e. pixels)
@@ -222,5 +241,3 @@ export function drawArrow(
   ctx.closePath();
   ctx.fill();
 }
-
-

--- a/assets/js/draw/shapes.ts
+++ b/assets/js/draw/shapes.ts
@@ -56,7 +56,7 @@ export function drawLineInScale(
 export function drawLine(
   ctx: CanvasRenderingContext2D,
   coords: Box,
-  style: LineStyle = {},
+  style: LineStyle = { },
 ) {
   const {
     lineWidth = 1,

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -25,11 +25,11 @@ export class API {
     return details;
   }
 
-  getTranscriptDetails(id: string): Promise<ApiTranscriptDetails> {
+  getTranscriptDetails(id: string): Promise<ApiGeneDetails> {
     const details = get(
       new URL(`tracks/transcripts/transcript/${id}`, this.apiURI).href,
       {},
-    ) as Promise<ApiTranscriptDetails>;
+    ) as Promise<ApiGeneDetails>;
     return details;
   }
 

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -68,7 +68,7 @@ interface ApiTranscriptFeature {
   exon_number: number,
 }
 
-interface ApiTranscriptDetails {
+interface ApiGeneDetails {
   transcript_id: string,
   transcript_biotype: string,
   gene_name: string,

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -461,7 +461,6 @@ interface DragCallbacks {
 
 interface Axis {
   range: Rng;
-  ticks: number[];
 }
 
 interface HighlightCallbacks {

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -238,3 +238,13 @@ export function generateID() {
   return `${ts}-${rand64}`;
 }
 
+export function generateTicks(range: Rng, step: number) {
+  const factor = 1000;
+  const first = Math.ceil(range[0] * 1000 / (step * 1000)) * step;
+
+  const ticks = [];
+  for (let v = first; v <= range[1]; v += step) {
+    ticks.push(Math.round(v * 10) / 10);
+  }
+  return ticks;
+}

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -240,11 +240,32 @@ export function generateID() {
 
 export function generateTicks(range: Rng, step: number) {
   const factor = 1000;
-  const first = Math.ceil(range[0] * 1000 / (step * 1000)) * step;
+  // Factor needed as ceil works with integers
+  const first = Math.ceil((range[0] * factor) / (step * factor)) * step;
 
   const ticks = [];
   for (let v = first; v <= range[1]; v += step) {
     ticks.push(Math.round(v * 10) / 10);
   }
   return ticks;
+}
+
+/**
+ * Tick size calculations for y-axis
+ * Values are selected manually at the moment
+ * If this grows, it might have to be automated
+ */
+export function getTickSize(range: Rng): number {
+  const size = rangeSize(range);
+
+  if (size > 3) {
+    return 1;
+  }
+  if (size > 1.5) {
+    return 0.5;
+  }
+  if (size > 0.75) {
+    return 0.2;
+  }
+  return 0.1;
 }


### PR DESCRIPTION
Close #344

Populating the tracks menu with some actual functionality.

Same as in the tracks panel in settings (in many cases more useful to have it here, such as when moving a track).

Also adds y-axis control for dot-charts (and with that, some y-tick logic).

![track_controls](https://github.com/user-attachments/assets/41b84505-fe36-4ea2-90f3-0807e4ba077f)
