### PR TITLE
More granular settings for render

### DIFF
--- a/assets/js/components/tracks/band_track.ts
+++ b/assets/js/components/tracks/band_track.ts
@@ -59,7 +59,7 @@ export class BandTrack extends DataTrack {
     this.initializeHoverTooltip();
     this.initializeClick(onElementClick);
     const startExpanded = false;
-    const onExpand = () => this.render(false);
+    const onExpand = () => this.render({});
     this.initializeExpander("contextmenu", startExpanded, onExpand);
   }
 

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -105,7 +105,7 @@ export class CanvasTrack extends ShadowBaseElement {
 
   // Placeholder needed for Typescript to understand that an array of CanvasTracks
   // can all be rendered as such: canvas.render(updateData);
-  async render(_updateData: boolean) {}
+  async render(_updateData: RenderSettings) {}
 
 
   initializeClick(onElementClick: (el: HoverBox) => void | null = null) {

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -5,14 +5,14 @@ import {
   renderBackground,
 } from "../../../draw/render_utils";
 import { drawHorizontalLineInScale, drawLabel } from "../../../draw/shapes";
-import { generateID, generateTicks, getTickSize, rangeSize } from "../../../util/utils";
+import { generateID, generateTicks, getTickSize } from "../../../util/utils";
 import {
   setupCanvasClick,
   setCanvasPointerCursor,
 } from "../../util/canvas_interaction";
 import { keyLogger } from "../../util/keylogger";
 import { CanvasTrack } from "./canvas_track";
-import { initializeDragSelect, renderHighlights } from "./interactive_tools";
+import { renderHighlights } from "./interactive_tools";
 
 import debounce from "lodash.debounce";
 
@@ -185,7 +185,7 @@ export class DataTrack extends CanvasTrack {
     });
   }
 
-  async render(updateData: boolean) {
+  async render(settings: RenderSettings) {
     // The intent with the debounce keeping track of the rendering number (_renderSeq)
     // is to prevent repeated API requests when rapidly zooming/panning
     // Only the last request is of interest
@@ -203,7 +203,7 @@ export class DataTrack extends CanvasTrack {
       { leading: false, trailing: true },
     );
 
-    if (updateData || this.renderData == null) {
+    if (settings.dataUpdated || this.renderData == null) {
       this.renderLoading();
       _fetchData();
     } else {

--- a/assets/js/components/tracks/dot_track.ts
+++ b/assets/js/components/tracks/dot_track.ts
@@ -38,7 +38,7 @@ export class DotTrack extends DataTrack {
 
   initialize() {
     super.initialize();
-    const onExpand = () => this.render(false);
+    const onExpand = () => this.render({});
     this.initializeExpander("contextmenu", this.startExpanded, onExpand);
     this.setExpandedHeight(this.defaultTrackHeight * 2);
   }

--- a/assets/js/components/tracks/ideogram_track.ts
+++ b/assets/js/components/tracks/ideogram_track.ts
@@ -29,8 +29,8 @@ export class IdeogramTrack extends CanvasTrack {
     this.initializeHoverTooltip();
   }
 
-  async render(updateData: boolean) {
-    if (updateData || this.renderData == null) {
+  async render(settings: RenderSettings) {
+    if (settings.dataUpdated || this.renderData == null) {
       this.renderData = await this.getRenderData();
     }
 

--- a/assets/js/components/tracks/multi_track.ts
+++ b/assets/js/components/tracks/multi_track.ts
@@ -1,3 +1,4 @@
+// FIXME: Not used anymore? Remove?
 import { removeChildren } from "../../util/utils";
 import { ShadowBaseElement as ShadowBaseElement } from "../util/shadowbaseelement";
 import { BandTrack } from "./band_track";
@@ -72,7 +73,7 @@ export class MultiBandTracks extends ShadowBaseElement {
     this.tracks = tracks;
   }
 
-  async render(updateData: boolean) {
+  async render(settings: RenderSettings) {
     const selectedSources = this.getSources();
     const trackSources = this.tracks.map((track) => track.id);
     const tracksDiffer = checkTracksDiffer(
@@ -84,7 +85,9 @@ export class MultiBandTracks extends ShadowBaseElement {
       const initialize = true;
       await this.updateTracks(selectedSources, initialize);
     }
-    this.tracks.forEach((track) => track.render(updateData || tracksDiffer));
+    this.tracks.forEach((track) =>
+      track.render({ dataUpdated: settings.dataUpdated || tracksDiffer }),
+    );
   }
 }
 

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -2,7 +2,6 @@ import { drawLabel, drawVerticalLineInScale } from "../../draw/shapes";
 import {
   transformMap,
   padRange,
-  rangeSize,
   generateID,
 } from "../../util/utils";
 import { COLORS, STYLE } from "../../constants";
@@ -85,7 +84,6 @@ export class OverviewTrack extends CanvasTrack {
   }
 
   async render(settings: RenderSettings) {
-    console.log("Rendering with settings:", settings);
 
     // FIXME: This one is a bit tricky isn't it
     // We want it to render not on new data, but on resize
@@ -164,16 +162,10 @@ export class OverviewTrack extends CanvasTrack {
     );
 
     const chromStartPos = chromRanges[chromosome][0];
-
-    console.log("chromStartPos", chromStartPos);
-    console.log("All ranges", chromRanges);
-
     const viewPxRange: Rng = [
       xScale(xRange[0] + chromStartPos),
       xScale(xRange[1] + chromStartPos),
     ];
-
-    console.log("Rendering marker for range", viewPxRange);
     this.marker.render(viewPxRange);
   }
 }

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -304,7 +304,7 @@ export class TracksManager extends ShadowBaseElement {
       () => dataSource.getOverviewCovData(sampleIds[0]),
       COV_Y_RANGE,
       chromSizes,
-      chromClick
+      chromClick,
     );
 
     const overviewTrackBaf = this.getOverviewTrack(
@@ -313,7 +313,7 @@ export class TracksManager extends ShadowBaseElement {
       () => dataSource.getOverviewCovData(sampleIds[0]),
       BAF_Y_RANGE,
       chromSizes,
-      chromClick
+      chromClick,
     );
 
     this.overviewTracks = [overviewTrackCov, overviewTrackBaf];
@@ -606,7 +606,7 @@ export class TracksManager extends ShadowBaseElement {
           chrom,
           start: xRange[0],
           end: xRange[1],
-        }
+        };
       },
       true,
     );

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -16,7 +16,6 @@ import { CHROMOSOMES } from "./constants";
 import { SideMenu } from "./components/side_menu";
 import { SettingsPage } from "./components/settings_page";
 import { HeaderInfo } from "./components/header_info";
-import { DataTrack } from "./components/tracks/base_tracks/data_track";
 
 export async function initCanvases({
   caseId,
@@ -61,16 +60,15 @@ export async function initCanvases({
     },
   );
 
-  const render = (updatedData: boolean) => {
-    gensTracks.render(updatedData);
+  const render = (settings: RenderSettings) => {
+    gensTracks.render(settings);
     settingsPage.render();
   };
 
   const onChromClick = async (chrom) => {
     const chromData = await api.getChromData(chrom);
     inputControls.updateChromosome(chrom, chromData.size);
-    const updateData = true;
-    render(updateData);
+    render({ dataUpdated: true });
   };
 
   const getChromInfo = async (chromosome: string): Promise<ChromosomeInfo> => {
@@ -99,11 +97,11 @@ export async function initCanvases({
     });
 
   settingsPage.setSources(
-    () => render(false),
+    () => render({}),
     annotSources,
     defaultAnnot,
     (_newSources) => {
-      render(true);
+      render({ dataUpdated: false });
     },
     () => gensTracks.getDataTracks(),
     (trackId: string, direction: "up" | "down") =>
@@ -138,7 +136,7 @@ export async function initCanvases({
 }
 
 async function initialize(
-  render: (updatedData: boolean) => void,
+  render: (settings: RenderSettings) => void,
   sampleIds: string[],
   inputControls: InputControls,
   tracks: TracksManager,
@@ -171,22 +169,22 @@ async function initialize(
     },
     removeHighlights: () => {
       highlights = {};
-      render(false);
+      render({});
     },
     addHighlight: (id: string, range: Rng) => {
       highlights[id] = range;
-      render(false);
+      render({});
     },
     removeHighlight: (id: string) => {
       delete highlights[id];
-      render(false);
+      render({});
     },
   };
 
   inputControls.initialize(
     startRegion,
     async (_range) => {
-      render(true);
+      render({ dataUpdated: true });
     },
     highlightCallbacks.removeHighlights,
   );
@@ -201,7 +199,7 @@ async function initialize(
     () => inputControls.getRange(),
     (range: Rng) => {
       inputControls.updatePosition(range);
-      render(true);
+      render({ dataUpdated: true });
     },
     () => inputControls.zoomOut(),
     () => settingsPage.getAnnotSources(),
@@ -218,7 +216,7 @@ async function initialize(
     highlightCallbacks,
   );
 
-  render(true);
+  render({ dataUpdated: true, resized: true });
 }
 
 function setupShortcuts(

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -469,3 +469,8 @@ interface HighlightCallbacks {
   addHighlight: (id: string, range: Rng) => void;
   removeHighlight: (id: string) =>  void;
 }
+
+interface RenderSettings {
+  dataUpdated?: boolean,
+  resized?: boolean,
+}


### PR DESCRIPTION
Distinguish region updates (chrom, pos), window resize and others to allow more efficient rendering.

In particular the overview plot can make sure to only rerender on resize (while updating only the marking on region updates).