### PR TITLE
Refactor tracks manager

### DIFF
--- a/assets/js/components/header_info.ts
+++ b/assets/js/components/header_info.ts
@@ -57,7 +57,7 @@ export class HeaderInfo extends ShadowBaseElement {
     caseURL: string,
   ) {
     this.caseIdElem.innerHTML = caseId;
-    this.caseIdElem.href = caseId;
+    this.caseIdElem.href = caseURL;
     this.sampleIdsElem.innerHTML = sampleIds.join(", ");
   }
 }

--- a/assets/js/components/header_info.ts
+++ b/assets/js/components/header_info.ts
@@ -29,7 +29,7 @@ template.innerHTML = String.raw`
 <div id="container">
   <div class="row text">
     <div class="label">Case </div>
-    <div id="case-id">(value)</div>
+    <a href="" id="case-id">(value)</a>
   </div>
   <div class="row text">
     <div class="label">Sample </div>
@@ -39,7 +39,7 @@ template.innerHTML = String.raw`
 `;
 
 export class HeaderInfo extends ShadowBaseElement {
-  private caseIdElem: HTMLDivElement;
+  private caseIdElem: HTMLAnchorElement;
   private sampleIdsElem: HTMLDivElement;
 
   constructor() {
@@ -47,14 +47,17 @@ export class HeaderInfo extends ShadowBaseElement {
   }
 
   connectedCallback(): void {
-    this.caseIdElem = this.root.querySelector("#case-id") as HTMLDivElement;
-    this.sampleIdsElem = this.root.querySelector(
-      "#sample-ids",
-    ) as HTMLDivElement;
+    this.caseIdElem = this.root.querySelector("#case-id");
+    this.sampleIdsElem = this.root.querySelector("#sample-ids");
   }
 
-  initialize(caseId: string, sampleIds: string[]) {
+  initialize(
+    caseId: string,
+    sampleIds: string[],
+    caseURL: string,
+  ) {
     this.caseIdElem.innerHTML = caseId;
+    this.caseIdElem.href = caseId;
     this.sampleIdsElem.innerHTML = sampleIds.join(", ");
   }
 }

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -35,42 +35,6 @@ template.innerHTML = String.raw`
   </div>
 `;
 
-// class RegionController {
-//   _chrom: string;
-//   _start: number;
-//   _end: number;
-//   constructor(region: Region) {
-//     this._chrom = region.chrom;
-//     this._start = region.start;
-//     this._end = region.end;
-//   }
-
-//   updateRange(range: Rng) {
-//     this._start = range[0];
-//     this._end = range[1];
-//   }
-
-//   getChrom(): string {
-//     return this._chrom;
-//   }
-
-//   getRange(): Rng {
-//     return [this._start, this._end];
-//   }
-
-//   getString() {
-//     return `${this._chrom}:${this._start}-${this._end}`;
-//   }
-
-//   getRegion(): Region {
-//     return {
-//       chrom: this._chrom,
-//       start: this._start,
-//       end: this._end,
-//     };
-//   }
-// }
-
 export class InputControls extends HTMLElement {
   private panLeftButton: HTMLButtonElement;
   private panRightButton: HTMLButtonElement;
@@ -79,9 +43,6 @@ export class InputControls extends HTMLElement {
   private regionField: HTMLInputElement;
   private removeHighlights: HTMLButtonElement;
   private toggleMarkerButton: HTMLButtonElement;
-
-  // private region: RegionController;
-  // private currChromLength: number;
 
   private onPositionChange: (newXRange: [number, number]) => void;
   private getMarkerOn: () => boolean;
@@ -105,47 +66,16 @@ export class InputControls extends HTMLElement {
     ) as HTMLButtonElement;
   }
 
-  // getRegion(): Region {
-  //   return this.region.getRegion();
-  // }
-
-  // getRange(): [number, number] {
-  //   if (this.regionField.value == null) {
-  //     throw Error("Must initialize before accessing getRange");
-  //   }
-  //   const region = parseRegionDesignation(this.regionField.value);
-  //   return [region.start, region.end];
-  // }
-
-  // updateChromosome(chrom: string, chromLength: number) {
-  //   this.region = new RegionController({ chrom, start: 1, end: chromLength });
-  //   this.regionField.value = this.region.getString();
-  //   this.currChromLength = chromLength;
-  // }
-
-  // updatePosition(range: [number, number]) {
-  //   this.region.updateRange(range);
-  //   this.regionField.value = this.region.getString();
-  // }
-
   initialize(
     session: GensSession,
-    // fullRegion: Region,
     onPositionChange: (newXRange: [number, number]) => void,
-    // session: GensSession,
   ) {
-    // this.region = new RegionController(fullRegion);
-    // this.updatePosition([fullRegion.start, fullRegion.end]);
-
-    // this.session = session;
-
     this.session = session;
 
     this.getMarkerOn = () => this.session.getMarkerModeOn();
     this.onToggleMarker = () => this.session.toggleMarkerMode();
 
     this.onPositionChange = onPositionChange;
-    // this.currChromLength = fullRegion.end;
 
     this.panLeftButton.onclick = () => {
       this.panLeft();
@@ -179,38 +109,26 @@ export class InputControls extends HTMLElement {
   panLeft() {
     const currRange = this.session.getXRange();
     const newXRange = getPan(currRange, "left", 1);
-    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   panRight() {
     const currXRange = this.session.getXRange();
-    console.log("Pan right start range", currXRange);
     const newXRange = getPan(
       currXRange,
       "right",
       this.session.getCurrentChromSize(),
     );
-    console.log("Pan right new range", newXRange);
-    // const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
-    // const newXRange: Rng = [newXRangeRaw[0], newMax];
-    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   zoomIn() {
     const currXRange = this.session.getXRange();
     const newXRange = zoomIn(currXRange);
-    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   zoomOut() {
-    // const currXRange = this.session.getXRange();
-    // const newXRangeRaw = zoomOut(currXRange);
-    // const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
-    // const newXRange: Rng = [Math.floor(newXRangeRaw[0]), Math.floor(newMax)];
-    // this.updatePosition(newXRange);
     const newXRange = zoomOut(
       this.session.getXRange(),
       this.session.getCurrentChromSize(),
@@ -220,7 +138,6 @@ export class InputControls extends HTMLElement {
 
   resetZoom() {
     const xRange = [1, this.session.getCurrentChromSize()] as Rng;
-    // this.updatePosition(xRange);
     this.onPositionChange(xRange);
   }
 

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -1,11 +1,6 @@
 import { COLORS, ICONS } from "../constants";
 import { GensSession } from "../state/gens_session";
-import {
-  getPan,
-  parseRegionDesignation,
-  zoomIn,
-  zoomOut,
-} from "../util/navigation";
+import { getPan, zoomIn, zoomOut } from "../util/navigation";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -1,5 +1,5 @@
 import { COLORS, ICONS } from "../constants";
-import { GensSession } from "../state/session";
+import { GensSession } from "../state/gens_session";
 import {
   getPan,
   parseRegionDesignation,
@@ -35,41 +35,41 @@ template.innerHTML = String.raw`
   </div>
 `;
 
-class RegionController {
-  _chrom: string;
-  _start: number;
-  _end: number;
-  constructor(region: Region) {
-    this._chrom = region.chrom;
-    this._start = region.start;
-    this._end = region.end;
-  }
+// class RegionController {
+//   _chrom: string;
+//   _start: number;
+//   _end: number;
+//   constructor(region: Region) {
+//     this._chrom = region.chrom;
+//     this._start = region.start;
+//     this._end = region.end;
+//   }
 
-  updateRange(range: Rng) {
-    this._start = range[0];
-    this._end = range[1];
-  }
+//   updateRange(range: Rng) {
+//     this._start = range[0];
+//     this._end = range[1];
+//   }
 
-  getChrom(): string {
-    return this._chrom;
-  }
+//   getChrom(): string {
+//     return this._chrom;
+//   }
 
-  getRange(): Rng {
-    return [this._start, this._end];
-  }
+//   getRange(): Rng {
+//     return [this._start, this._end];
+//   }
 
-  getString() {
-    return `${this._chrom}:${this._start}-${this._end}`;
-  }
+//   getString() {
+//     return `${this._chrom}:${this._start}-${this._end}`;
+//   }
 
-  getRegion(): Region {
-    return {
-      chrom: this._chrom,
-      start: this._start,
-      end: this._end,
-    };
-  }
-}
+//   getRegion(): Region {
+//     return {
+//       chrom: this._chrom,
+//       start: this._start,
+//       end: this._end,
+//     };
+//   }
+// }
 
 export class InputControls extends HTMLElement {
   private panLeftButton: HTMLButtonElement;
@@ -80,12 +80,14 @@ export class InputControls extends HTMLElement {
   private removeHighlights: HTMLButtonElement;
   private toggleMarkerButton: HTMLButtonElement;
 
-  private region: RegionController;
+  // private region: RegionController;
   private currChromLength: number;
 
   private onPositionChange: (newXRange: [number, number]) => void;
   private getMarkerOn: () => boolean;
   private onToggleMarker: () => void;
+
+  private session: GensSession;
 
   connectedCallback() {
     this.appendChild(template.content.cloneNode(true));
@@ -103,40 +105,47 @@ export class InputControls extends HTMLElement {
     ) as HTMLButtonElement;
   }
 
-  getRegion(): Region {
-    return this.region.getRegion();
-  }
+  // getRegion(): Region {
+  //   return this.region.getRegion();
+  // }
 
-  getRange(): [number, number] {
-    if (this.regionField.value == null) {
-      throw Error("Must initialize before accessing getRange");
-    }
-    const region = parseRegionDesignation(this.regionField.value);
-    return [region.start, region.end];
-  }
+  // getRange(): [number, number] {
+  //   if (this.regionField.value == null) {
+  //     throw Error("Must initialize before accessing getRange");
+  //   }
+  //   const region = parseRegionDesignation(this.regionField.value);
+  //   return [region.start, region.end];
+  // }
 
-  updateChromosome(chrom: string, chromLength: number) {
-    this.region = new RegionController({ chrom, start: 1, end: chromLength });
-    this.regionField.value = this.region.getString();
-    this.currChromLength = chromLength;
-  }
+  // updateChromosome(chrom: string, chromLength: number) {
+  //   this.region = new RegionController({ chrom, start: 1, end: chromLength });
+  //   this.regionField.value = this.region.getString();
+  //   this.currChromLength = chromLength;
+  // }
 
-  updatePosition(range: [number, number]) {
-    this.region.updateRange(range);
-    this.regionField.value = this.region.getString();
-  }
+  // updatePosition(range: [number, number]) {
+  //   this.region.updateRange(range);
+  //   this.regionField.value = this.region.getString();
+  // }
 
   initialize(
-    fullRegion: Region,
-    onPositionChange: (newXRange: [number, number]) => void,
     session: GensSession,
+    // fullRegion: Region,
+    onPositionChange: (newXRange: [number, number]) => void,
+    // session: GensSession,
   ) {
-    this.region = new RegionController(fullRegion);
-    this.updatePosition([fullRegion.start, fullRegion.end]);
+    // this.region = new RegionController(fullRegion);
+    // this.updatePosition([fullRegion.start, fullRegion.end]);
+
+    // this.session = session;
+
+    this.session = session;
+
+    this.getMarkerOn = () => this.session.getMarkerModeOn();
+    this.onToggleMarker = () => this.session.toggleMarkerMode();
+
     this.onPositionChange = onPositionChange;
-    this.currChromLength = fullRegion.end;
-    this.getMarkerOn = () => session.getMarkerModeOn();
-    this.onToggleMarker = () => session.toggleMarkerMode();
+    // this.currChromLength = fullRegion.end;
 
     this.panLeftButton.onclick = () => {
       this.panLeft();
@@ -154,49 +163,54 @@ export class InputControls extends HTMLElement {
       this.zoomOut();
     };
 
-    this.removeHighlights.onclick = () => session.removeHighlights();
-    this.toggleMarkerButton.onclick = () => session.toggleMarkerMode();
+    this.removeHighlights.onclick = () => this.session.removeHighlights();
+    this.toggleMarkerButton.onclick = () => this.session.toggleMarkerMode();
   }
 
   render(_settings: RenderSettings) {
     this.toggleMarkerButton.style.backgroundColor = this.getMarkerOn()
       ? COLORS.lightGray
       : "";
+
+    const region = this.session.getRegion();
+    this.regionField.value = `${region.chrom}:${region.start}-${region.end}`;
   }
 
   panLeft() {
-    const newXRange = getPan(this.getRange(), "left");
-    this.updatePosition(newXRange);
+    const currRange = this.session.getXRange();
+    const newXRange = getPan(currRange, "left");
+    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   panRight() {
-    const newXRangeRaw = getPan(this.getRange(), "right");
+    const currXRange = this.session.getXRange();
+    const newXRangeRaw = getPan(currXRange, "right");
     const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
     const newXRange: Rng = [newXRangeRaw[0], newMax];
-    this.updatePosition(newXRange);
+    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   zoomIn() {
-    const currXRange = this.getRange();
+    const currXRange = this.session.getXRange();
     const newXRange = zoomIn(currXRange);
-    this.updatePosition(newXRange);
+    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   zoomOut() {
-    const currXRange = this.getRange();
+    const currXRange = this.session.getXRange();
     const newXRangeRaw = zoomOut(currXRange);
     const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
     const newXRange: Rng = [Math.floor(newXRangeRaw[0]), Math.floor(newMax)];
-    this.updatePosition(newXRange);
+    // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   resetZoom() {
     const xRange = [1, this.currChromLength] as Rng;
-    this.updatePosition(xRange);
+    // this.updatePosition(xRange);
     this.onPositionChange(xRange);
   }
 

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -135,7 +135,7 @@ export class InputControls extends HTMLElement {
     this.updatePosition([fullRegion.start, fullRegion.end]);
     this.onPositionChange = onPositionChange;
     this.currChromLength = fullRegion.end;
-    this.getMarkerOn = () => session.getMarkerMode();
+    this.getMarkerOn = () => session.getMarkerModeOn();
     this.onToggleMarker = () => session.toggleMarkerMode();
 
     this.panLeftButton.onclick = () => {

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -81,7 +81,7 @@ export class InputControls extends HTMLElement {
   private toggleMarkerButton: HTMLButtonElement;
 
   // private region: RegionController;
-  private currChromLength: number;
+  // private currChromLength: number;
 
   private onPositionChange: (newXRange: [number, number]) => void;
   private getMarkerOn: () => boolean;
@@ -178,16 +178,22 @@ export class InputControls extends HTMLElement {
 
   panLeft() {
     const currRange = this.session.getXRange();
-    const newXRange = getPan(currRange, "left");
+    const newXRange = getPan(currRange, "left", 1);
     // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
 
   panRight() {
     const currXRange = this.session.getXRange();
-    const newXRangeRaw = getPan(currXRange, "right");
-    const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
-    const newXRange: Rng = [newXRangeRaw[0], newMax];
+    console.log("Pan right start range", currXRange);
+    const newXRange = getPan(
+      currXRange,
+      "right",
+      this.session.getCurrentChromSize(),
+    );
+    console.log("Pan right new range", newXRange);
+    // const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
+    // const newXRange: Rng = [newXRangeRaw[0], newMax];
     // this.updatePosition(newXRange);
     this.onPositionChange(newXRange);
   }
@@ -200,16 +206,20 @@ export class InputControls extends HTMLElement {
   }
 
   zoomOut() {
-    const currXRange = this.session.getXRange();
-    const newXRangeRaw = zoomOut(currXRange);
-    const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
-    const newXRange: Rng = [Math.floor(newXRangeRaw[0]), Math.floor(newMax)];
+    // const currXRange = this.session.getXRange();
+    // const newXRangeRaw = zoomOut(currXRange);
+    // const newMax = Math.min(newXRangeRaw[1], this.currChromLength);
+    // const newXRange: Rng = [Math.floor(newXRangeRaw[0]), Math.floor(newMax)];
     // this.updatePosition(newXRange);
+    const newXRange = zoomOut(
+      this.session.getXRange(),
+      this.session.getCurrentChromSize(),
+    );
     this.onPositionChange(newXRange);
   }
 
   resetZoom() {
-    const xRange = [1, this.currChromLength] as Rng;
+    const xRange = [1, this.session.getCurrentChromSize()] as Rng;
     // this.updatePosition(xRange);
     this.onPositionChange(xRange);
   }

--- a/assets/js/components/tracks/band_track.ts
+++ b/assets/js/components/tracks/band_track.ts
@@ -8,7 +8,7 @@ import { STYLE } from "../../constants";
 import { drawArrow, getLinearScale } from "../../draw/render_utils";
 import { drawLabel } from "../../draw/shapes";
 import { DataTrack } from "./base_tracks/data_track";
-import { GensSession } from "../../state/session";
+import { GensSession } from "../../state/gens_session";
 
 export class BandTrack extends DataTrack {
   getPopupInfo: (box: HoverBox) => Promise<PopupContent>;

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -1,5 +1,5 @@
 import { renderBackground } from "../../../draw/render_utils";
-import { drawLabel } from "../../../draw/shapes";
+import { drawBox, drawLabel } from "../../../draw/shapes";
 import { ShadowBaseElement } from "../../util/shadowbaseelement";
 import { setupCanvasClick, getCanvasHover } from "../../util/canvas_interaction";
 import { STYLE } from "../../../constants";
@@ -82,6 +82,13 @@ export abstract class CanvasTrack extends ShadowBaseElement {
 
     this.syncDimensions();
     this.isInitialized = true;
+  }
+
+  /**
+   * Draw a blue box straight into canvas for debugging
+   */
+  debugRender() {
+    drawBox(this.ctx, {x1: 1, x2: 100, y1: 1, y2: 100}, {fillColor: "blue"});
   }
 
   renderLoading() {

--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -1,9 +1,11 @@
 import { renderBackground } from "../../../draw/render_utils";
 import { drawBox, drawLabel } from "../../../draw/shapes";
 import { ShadowBaseElement } from "../../util/shadowbaseelement";
-import { setupCanvasClick, getCanvasHover } from "../../util/canvas_interaction";
+import {
+  setupCanvasClick,
+  getCanvasHover,
+} from "../../util/canvas_interaction";
 import { STYLE } from "../../../constants";
-
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`
@@ -58,7 +60,6 @@ export abstract class CanvasTrack extends ShadowBaseElement {
     this.collapsedTrackHeight = STYLE.tracks.trackHeight.extraThin;
   }
 
-
   getNtsPerPixel(xRange: Rng) {
     const nNts = xRange[1] - xRange[0];
     const nPxs = this.dimensions.width;
@@ -87,13 +88,16 @@ export abstract class CanvasTrack extends ShadowBaseElement {
   /**
    * Draw a blue box straight into canvas for debugging
    */
-  debugRender() {
-    drawBox(this.ctx, {x1: 1, x2: 100, y1: 1, y2: 100}, {fillColor: "blue"});
+  debugRender(
+    color: string = "blue",
+    box: Box = { x1: 1, x2: 100, y1: 1, y2: 100 },
+  ) {
+    drawBox(this.ctx, box, { fillColor: color });
   }
 
   renderLoading() {
     if (this.ctx == null) {
-      throw Error(`${this.label}: Track cannot be rendered before initialized`)
+      throw Error(`${this.label}: Track cannot be rendered before initialized`);
     }
     renderBackground(this.ctx, this.dimensions);
     drawLabel(
@@ -108,7 +112,6 @@ export abstract class CanvasTrack extends ShadowBaseElement {
   // Placeholder needed for Typescript to understand that an array of CanvasTracks
   // can all be rendered as such: canvas.render(updateData);
   async render(_updateData: RenderSettings) {}
-
 
   initializeClick(onElementClick: (el: HoverBox) => void | null = null) {
     setupCanvasClick(this.canvas, () => this.hoverTargets, onElementClick);

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -5,7 +5,7 @@ import {
   renderBackground,
 } from "../../../draw/render_utils";
 import { drawBox, drawLabel, drawLine } from "../../../draw/shapes";
-import { GensSession } from "../../../state/session";
+import { GensSession } from "../../../state/gens_session";
 import { generateTicks, getTickSize } from "../../../util/utils";
 import {
   setupCanvasClick,

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -226,7 +226,7 @@ export abstract class DataTrack extends CanvasTrack {
         const hoverTargets = this.hoverTargets ? this.hoverTargets : [];
         return hoverTargets.concat([labelBox]);
       },
-      () => this.session.getMarkerMode(),
+      () => this.session.getMarkerModeOn(),
       [0, STYLE.yAxis.width],
     );
   }

--- a/assets/js/components/tracks/base_tracks/interactive_tools.ts
+++ b/assets/js/components/tracks/base_tracks/interactive_tools.ts
@@ -1,11 +1,11 @@
 import { COLORS, STYLE } from "../../../constants";
+import { GensMarker } from "../../../movements/marker";
 import {
   generateID,
   scaleRange,
   sortRange,
 } from "../../../util/utils";
 import { keyLogger } from "../../util/keylogger";
-import { GensMarker } from "../../util/marker";
 
 export function initializeDragSelect(
   element: HTMLElement,

--- a/assets/js/components/tracks/dot_track.ts
+++ b/assets/js/components/tracks/dot_track.ts
@@ -1,6 +1,6 @@
 import { STYLE } from "../../constants";
 import { drawDotsScaled, getLinearScale } from "../../draw/render_utils";
-import { GensSession } from "../../state/session";
+import { GensSession } from "../../state/gens_session";
 import { DataTrack } from "./base_tracks/data_track";
 
 export class DotTrack extends DataTrack {

--- a/assets/js/components/tracks/ideogram_track.ts
+++ b/assets/js/components/tracks/ideogram_track.ts
@@ -3,7 +3,6 @@ import { STYLE } from "../../constants";
 import { CanvasTrack } from "./base_tracks/canvas_track";
 import "tippy.js/dist/tippy.css";
 import { getLinearScale } from "../../draw/render_utils";
-import { drawBox } from "../../draw/shapes";
 
 export class IdeogramTrack extends CanvasTrack {
   private markerElement: HTMLDivElement;

--- a/assets/js/components/tracks/ideogram_track.ts
+++ b/assets/js/components/tracks/ideogram_track.ts
@@ -23,28 +23,19 @@ export class IdeogramTrack extends CanvasTrack {
 
   initialize() {
 
-    console.log("Is it initialized");
-
     super.initialize();
     const zoomMarkerElement = setupZoomMarkerElement(this.defaultTrackHeight);
     this.trackContainer.appendChild(zoomMarkerElement);
     this.markerElement = zoomMarkerElement;
 
     this.initializeHoverTooltip();
-
-    this.debugRender();
   }
 
   async render(settings: RenderSettings) {
 
-    console.error("Render called with dimensions", this.dimensions);
-    // drawBox(this.ctx, {x1: 1, x2: 100, y1: 1, y2: 100}, {fillColor: "blue"});
-
     if (settings.dataUpdated || this.renderData == null) {
       this.renderData = await this.getRenderData();
     }
-
-    console.log(this.label, "rendering");
 
     super.syncDimensions();
     this.ctx.clearRect(0, 0, this.dimensions.width, this.dimensions.height);

--- a/assets/js/components/tracks/ideogram_track.ts
+++ b/assets/js/components/tracks/ideogram_track.ts
@@ -3,6 +3,7 @@ import { STYLE } from "../../constants";
 import { CanvasTrack } from "./base_tracks/canvas_track";
 import "tippy.js/dist/tippy.css";
 import { getLinearScale } from "../../draw/render_utils";
+import { drawBox } from "../../draw/shapes";
 
 export class IdeogramTrack extends CanvasTrack {
   private markerElement: HTMLDivElement;
@@ -21,18 +22,29 @@ export class IdeogramTrack extends CanvasTrack {
   }
 
   initialize() {
+
+    console.log("Is it initialized");
+
     super.initialize();
     const zoomMarkerElement = setupZoomMarkerElement(this.defaultTrackHeight);
     this.trackContainer.appendChild(zoomMarkerElement);
     this.markerElement = zoomMarkerElement;
 
     this.initializeHoverTooltip();
+
+    this.debugRender();
   }
 
   async render(settings: RenderSettings) {
+
+    console.error("Render called with dimensions", this.dimensions);
+    // drawBox(this.ctx, {x1: 1, x2: 100, y1: 1, y2: 100}, {fillColor: "blue"});
+
     if (settings.dataUpdated || this.renderData == null) {
       this.renderData = await this.getRenderData();
     }
+
+    console.log(this.label, "rendering");
 
     super.syncDimensions();
     this.ctx.clearRect(0, 0, this.dimensions.width, this.dimensions.height);

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -198,7 +198,7 @@ function renderOverviewPlot(
       // If exchanged for a different letter, this label is rendered, so is Y.
       // If keeping the "Y", nothing is rendered specifically for the Y label
       // More digging is needed here to understand this
-      let renderChrom = `${chrom}.`;
+      const renderChrom = `${chrom}.`;
       drawLabel(
         ctx,
         renderChrom,

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -46,8 +46,6 @@ export class OverviewTrack extends CanvasTrack {
   ) {
     super(id, label, trackHeight);
 
-    console.log("Overview track created");
-
     this.chromSizes = chromSizes;
     this.yRange = yRange;
     this.getRenderData = getRenderData;
@@ -61,8 +59,6 @@ export class OverviewTrack extends CanvasTrack {
 
   initialize() {
     super.initialize();
-
-    console.log("Overview track initialized");
 
     this.marker = document.createElement("gens-marker") as GensMarker;
     this.trackContainer.appendChild(this.marker);
@@ -85,15 +81,12 @@ export class OverviewTrack extends CanvasTrack {
 
   async render(settings: RenderSettings) {
 
-    console.log("Rendering overview track", settings);
-
     // FIXME: This one is a bit tricky isn't it
     // We want it to render not on new data, but on resize
     // Do I have all info I need here?
     // Should the renderData be more granular?
     let newRender = false;
     if (this.renderData == null || settings.resized) {
-      console.log("Getting new rendering data");
       newRender = this.renderData == null;
       this.renderData = await this.getRenderData();
     }
@@ -125,7 +118,6 @@ export class OverviewTrack extends CanvasTrack {
     ]);
 
     if (newRender) {
-      console.log("newRender triggered");
       super.syncDimensions();
       this.renderLoading();
 

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -7,7 +7,7 @@ import {
   linearScale,
   renderBackground,
 } from "../../draw/render_utils";
-import { GensMarker } from "../util/marker";
+import { GensMarker } from "../../movements/marker";
 
 const X_PAD = 5;
 const DOT_SIZE = 2;

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -46,6 +46,8 @@ export class OverviewTrack extends CanvasTrack {
   ) {
     super(id, label, trackHeight);
 
+    console.log("Overview track created");
+
     this.chromSizes = chromSizes;
     this.yRange = yRange;
     this.getRenderData = getRenderData;
@@ -59,6 +61,8 @@ export class OverviewTrack extends CanvasTrack {
 
   initialize() {
     super.initialize();
+
+    console.log("Overview track initialized");
 
     this.marker = document.createElement("gens-marker") as GensMarker;
     this.trackContainer.appendChild(this.marker);
@@ -80,12 +84,16 @@ export class OverviewTrack extends CanvasTrack {
   }
 
   async render(settings: RenderSettings) {
+
+    console.log("Rendering overview track", settings);
+
     // FIXME: This one is a bit tricky isn't it
     // We want it to render not on new data, but on resize
     // Do I have all info I need here?
     // Should the renderData be more granular?
     let newRender = false;
     if (this.renderData == null || settings.resized) {
+      console.log("Getting new rendering data");
       newRender = this.renderData == null;
       this.renderData = await this.getRenderData();
     }
@@ -117,6 +125,7 @@ export class OverviewTrack extends CanvasTrack {
     ]);
 
     if (newRender) {
+      console.log("newRender triggered");
       super.syncDimensions();
       this.renderLoading();
 

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -20,7 +20,7 @@ import { DataTrack } from "./tracks/base_tracks/data_track";
 import { diff, moveElement } from "../util/collections";
 
 import Sortable, { SortableEvent } from "sortablejs";
-import { GensSession } from "../state/session";
+import { GensSession } from "../state/gens_session";
 import {
   initializeDragSelect,
   renderHighlights,

--- a/assets/js/components/tracks_manager.ts
+++ b/assets/js/components/tracks_manager.ts
@@ -7,24 +7,20 @@ import { IdeogramTrack } from "./tracks/ideogram_track";
 import { OverviewTrack } from "./tracks/overview_track";
 import { DotTrack } from "./tracks/dot_track";
 import { BandTrack } from "./tracks/band_track";
-import { ANIM_TIME, COLORS, SIZES, STYLE } from "../constants";
+import { ANIM_TIME, SIZES, STYLE } from "../constants";
 import {
   getAnnotationContextMenuContent,
   getGenesContextMenuContent,
   getVariantContextMenuContent,
 } from "./util/menu_content_utils";
 import { ShadowBaseElement } from "./util/shadowbaseelement";
-import { generateID } from "../util/utils";
 import { getSimpleButton } from "./util/menu_utils";
 import { DataTrack } from "./tracks/base_tracks/data_track";
 import { diff, moveElement } from "../util/collections";
 
 import Sortable, { SortableEvent } from "sortablejs";
 import { GensSession } from "../state/gens_session";
-import {
-  initializeDragSelect,
-  renderHighlights,
-} from "./tracks/base_tracks/interactive_tools";
+import { renderHighlights } from "./tracks/base_tracks/interactive_tools";
 import { getLinearScale } from "../draw/render_utils";
 import { keyLogger } from "./util/keylogger";
 import { TrackPage } from "./side_menu/track_page";
@@ -119,17 +115,10 @@ export class TracksManager extends ShadowBaseElement {
   overviewTracks: OverviewTrack[];
   dataTracks: DataTrack[] = [];
 
-  // FIXME: Remove this one or?
   annotationTracks: DataTrack[] = [];
-  // getXRange: () => Rng;
-  // getChromosome: () => string;
-
-  // dragCallbacks: DragCallbacks;
-  // dataSource: RenderDataSource;
   myDataSources: TracksManagerDataSources;
   renderAll: (settings: RenderSettings) => void;
 
-  // getAnnotationSources: GetAnnotSources;
   getAnnotationDetails: (id: string) => Promise<ApiAnnotationDetails>;
   openTrackContextMenu: (track: DataTrack) => void;
   session: GensSession;
@@ -164,25 +153,11 @@ export class TracksManager extends ShadowBaseElement {
     sampleIds: string[],
     chromSizes: Record<string, number>,
     chromClick: (chrom: string) => void,
-    // dataSource: RenderDataSource,
-
-    // In session?
-    // getChromosome: () => string,
-    // getXRange: () => Rng,
-    // onZoomIn: (range: Rng) => void,
-    // onZoomOut: () => void,
-    // onPan: (panX: number) => void,
 
     myDataSources: TracksManagerDataSources,
     session: GensSession,
   ) {
-    // this.dataSource = dataSource;
     this.myDataSources = myDataSources;
-    // this.getAnnotationSources = getAnnotSources;
-    // this.getAnnotationDetails = getAnnotationDetails;
-
-    // this.getXRange = getXRange;
-    // this.getChromosome = getChromosome;
     this.session = session;
     this.renderAll = render;
 
@@ -213,13 +188,6 @@ export class TracksManager extends ShadowBaseElement {
       this.session.setViewRange(panRange);
     });
 
-    // this.dragCallbacks = {
-    //   onZoomIn,
-    //   onZoomOut,
-    //   getHighlights: session.getHighlights.bind(session),
-    //   addHighlight: session.addHighlight.bind(session),
-    //   removeHighlight: session.removeHighlight.bind(session),
-    // };
 
     this.openTrackContextMenu = (track: DataTrack) => {
       const isDotTrack = track instanceof DotTrack;
@@ -374,8 +342,6 @@ export class TracksManager extends ShadowBaseElement {
       (range: Rng) => session.setViewRange(range),
       (range: Rng) => session.addHighlight(range),
       (id: string) => session.removeHighlight(id),
-
-      // this.dragCallbacks,
     );
 
     this.tracksContainer.addEventListener("click", () => {

--- a/assets/js/components/tracks_manager/tracks_manager.ts
+++ b/assets/js/components/tracks_manager/tracks_manager.ts
@@ -6,16 +6,8 @@ import "../tracks/overview_track";
 import { IdeogramTrack } from "../tracks/ideogram_track";
 import { OverviewTrack } from "../tracks/overview_track";
 import { DotTrack } from "../tracks/dot_track";
-import { BandTrack } from "../tracks/band_track";
 import { ANIM_TIME, SIZES, STYLE } from "../../constants";
-import {
-  getAnnotationContextMenuContent,
-  getGenesContextMenuContent,
-  getVariantContextMenuContent,
-} from "../util/menu_content_utils";
 import { ShadowBaseElement } from "../util/shadowbaseelement";
-import { getSimpleButton } from "../util/menu_utils";
-import { DataTrack } from "../tracks/base_tracks/data_track";
 import { diff, moveElement } from "../../util/collections";
 
 import Sortable, { SortableEvent } from "sortablejs";
@@ -35,6 +27,7 @@ import {
   TRACK_HANDLE_CLASS,
   createAnnotTrack,
 } from "./utils";
+import { DataTrack } from "../tracks/base_tracks/data_track";
 
 const COV_Y_RANGE: [number, number] = [-3, 3];
 const BAF_Y_RANGE: [number, number] = [0, 1];
@@ -257,7 +250,6 @@ export class TracksManager extends ShadowBaseElement {
       chromSizes,
       chromClick,
       session,
-      openTrackContextMenu,
     );
 
     const overviewTrackBaf = createOverviewTrack(
@@ -268,16 +260,15 @@ export class TracksManager extends ShadowBaseElement {
       chromSizes,
       chromClick,
       session,
-      openTrackContextMenu,
     );
 
     this.overviewTracks = [overviewTrackCov, overviewTrackBaf];
 
     this.dataTracks.push(
       ...covTracks,
-      ...bafTracks,
-      ...variantTracks,
-      genesTrack,
+      // ...bafTracks,
+      // ...variantTracks,
+      // genesTrack,
     );
 
     this.topContainer.appendChild(this.ideogramTrack);
@@ -378,37 +369,48 @@ export class TracksManager extends ShadowBaseElement {
   }
 
   render(settings: RenderSettings) {
-    renderHighlights(
-      this.tracksContainer,
-      this.session.getCurrentHighlights(),
-      this.getXScale(),
-      (id) => this.session.removeHighlight(id),
-    );
+    // renderHighlights(
+    //   this.tracksContainer,
+    //   this.session.getCurrentHighlights(),
+    //   this.getXScale(),
+    //   (id) => this.session.removeHighlight(id),
+    // );
 
-    updateAnnotationTracks(
-      this.dataSources,
-      this.session,
-      this.openTrackContextMenu,
-      this.addDataTrack,
-      this.removeDataTrack,
-    );
+    // updateAnnotationTracks(
+    //   this.dataSources,
+    //   this.session,
+    //   this.openTrackContextMenu,
+    //   this.addDataTrack,
+    //   this.removeDataTrack,
+    // );
 
-    for (const trackPage of Object.values(this.trackPages)) {
-      trackPage.render(settings);
+    // for (const trackPage of Object.values(this.trackPages)) {
+    //   trackPage.render(settings);
+    // }
+
+    console.log("Render");
+
+    for (const dataTrack of this.dataTracks) {
+      dataTrack.debugRender();
     }
+
+    this.ideogramTrack.debugRender();
 
     this.ideogramTrack.render(settings);
 
     for (const track of this.dataTracks) {
       track.render(settings);
+      track.debugRender();
     }
 
-    this.overviewTracks.forEach((track) => track.render(settings));
+    // this.overviewTracks.forEach((track) => track.render(settings));
   }
 
-  addDataTrack(newTrack: DataTrack) {
+  addDataTrack(newTrack: DataTrack, isAnnotation: boolean) {
     this.dataTracks.push(newTrack);
-    this.annotationTracks.push(newTrack);
+    if (isAnnotation) {
+      this.annotationTracks.push(newTrack);
+    }
     const trackWrapper = createDataTrackWrapper(newTrack);
     this.tracksContainer.appendChild(trackWrapper);
     newTrack.initialize();
@@ -479,7 +481,7 @@ function updateAnnotationTracks(
     selectedOnly: true,
   });
 
-  const currAnnotTracks = this.annotationTracks;
+  const currAnnotTracks = dataSources.getAnnotationSources({selectedOnly: true});
 
   const newSources = diff(sources, currAnnotTracks, (source) => source.id);
   const removedSources = diff(currAnnotTracks, sources, (source) => source.id);
@@ -497,7 +499,6 @@ function updateAnnotationTracks(
 
   removedSources.forEach((source) => {
     removeTrack(source.id);
-
   });
 }
 

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -1,0 +1,236 @@
+import { STYLE } from "../../constants";
+import { GensSession } from "../../state/gens_session";
+import { BandTrack } from "../tracks/band_track";
+import { DataTrack } from "../tracks/base_tracks/data_track";
+import { DotTrack } from "../tracks/dot_track";
+import { OverviewTrack } from "../tracks/overview_track";
+import {
+  getAnnotationContextMenuContent,
+  getGenesContextMenuContent,
+  getVariantContextMenuContent,
+} from "../util/menu_content_utils";
+import { getSimpleButton } from "../util/menu_utils";
+import { TracksManagerDataSources } from "./tracks_manager";
+
+const trackHeight = STYLE.tracks.trackHeight;
+
+export const TRACK_HANDLE_CLASS = "track-handle";
+
+export function createAnnotTrack(
+  sourceId: string,
+  label: string,
+  dataSources: TracksManagerDataSources,
+  session: GensSession,
+  openTrackContextMenu: (track: DataTrack) => void,
+): BandTrack {
+  async function getAnnotTrackData(
+    source: string,
+    getXRange: () => Rng,
+    getAnnotation: (source: string) => Promise<RenderBand[]>,
+  ): Promise<BandTrackData> {
+    const bands = await getAnnotation(source);
+    return {
+      xRange: getXRange(),
+      bands,
+    };
+  }
+
+  const openContextMenuId = async (id: string) => {
+    const details = await dataSources.getAnnotationDetails(id);
+    const button = getSimpleButton("Set highlight", () => {
+      session.addHighlight([details.start, details.end]);
+    });
+    const entries = getAnnotationContextMenuContent(id, details);
+    const content = [button];
+    content.push(...entries);
+    session.showContent("Annotations", content);
+  };
+
+  const track = new BandTrack(
+    sourceId,
+    label,
+    trackHeight.thin,
+    () => session.getXRange(),
+    () =>
+      getAnnotTrackData(
+        sourceId,
+        () => session.getXRange(),
+        dataSources.getAnnotation,
+      ),
+    openContextMenuId,
+    openTrackContextMenu,
+    session,
+  );
+  return track;
+}
+
+export function createDotTrack(
+  id: string,
+  label: string,
+  sampleId: string,
+  dataFn: (sampleId: string) => Promise<RenderDot[]>,
+  settings: { startExpanded: boolean; yAxis: Axis },
+  session: GensSession,
+  openTrackContextMenu: (track: DataTrack) => void,
+): DotTrack {
+  const dotTrack = new DotTrack(
+    id,
+    label,
+    trackHeight.thick,
+    settings.startExpanded,
+    settings.yAxis,
+    () => session.getXRange(),
+    async () => {
+      const data = await dataFn(sampleId);
+      // const data = await this.dataSource.getCovData(sampleId);
+      return {
+        xRange: session.getXRange(),
+        dots: data,
+      };
+    },
+    openTrackContextMenu,
+    session,
+  );
+  return dotTrack;
+}
+
+export function createVariantTrack(
+  id: string,
+  label: string,
+  sampleId: string,
+  dataFn: (sampleId: string) => Promise<RenderBand[]>,
+  getVariantDetails: (
+    sampleId: string,
+    variantId: string,
+  ) => Promise<ApiVariantDetails>,
+  getVariantURL: (variantId: string) => string,
+  session: GensSession,
+  openTrackContextMenu: (track: DataTrack) => void,
+): BandTrack {
+  const variantTrack = new BandTrack(
+    id,
+    label,
+    trackHeight.thin,
+    () => session.getXRange(),
+    async () => {
+      return {
+        xRange: session.getXRange(),
+        bands: await dataFn(sampleId),
+      };
+    },
+    async (variantId: string) => {
+      const details = await getVariantDetails(sampleId, variantId);
+      const scoutUrl = getVariantURL(variantId);
+
+      const button = getSimpleButton("Set highlight", () => {
+        session.addHighlight([details.position, details.end]);
+      });
+
+      const entries = getVariantContextMenuContent(
+        variantId,
+        details,
+        scoutUrl,
+      );
+      const content = [button];
+      content.push(...entries);
+
+      session.showContent("Variant", content);
+    },
+    openTrackContextMenu,
+    session,
+  );
+  return variantTrack;
+}
+
+export function createGenesTrack(
+  id: string,
+  label: string,
+  getBands: () => Promise<RenderBand[]>,
+  getDetails: (id: string) => Promise<ApiGeneDetails>,
+  session: GensSession,
+  openTrackContextMenu: (track: DataTrack) => void,
+): BandTrack {
+  const genesTrack = new BandTrack(
+    id,
+    label,
+    trackHeight.thin,
+    () => session.getXRange(),
+    async () => {
+      return {
+        xRange: session.getXRange(),
+        bands: await getBands(),
+      };
+    },
+    async (id) => {
+      const details = await getDetails(id);
+      const button = getSimpleButton("Set highlight", () => {
+        session.addHighlight([details.start, details.end]);
+      });
+      const entries = getGenesContextMenuContent(id, details);
+      const content = [button];
+      content.push(...entries);
+      session.showContent("Transcript", content);
+    },
+    openTrackContextMenu,
+    session,
+  );
+  return genesTrack;
+}
+
+export function createOverviewTrack(
+  id: string,
+  label: string,
+  getData: () => Promise<Record<string, RenderDot[]>>,
+  yRange: Rng,
+  chromSizes: Record<string, number>,
+  chromClick: (chrom: string) => void,
+  session: GensSession,
+  openTrackContextMenu: (track: DataTrack) => void,
+): OverviewTrack {
+  const overviewTrack = new OverviewTrack(
+    id,
+    label,
+    trackHeight.thick,
+    chromSizes,
+    chromClick,
+    yRange,
+    async () => {
+      return {
+        dotsPerChrom: await getData(),
+        xRange: session.getXRange(),
+        chromosome: session.getChromosome(),
+      };
+    },
+    () => {
+      const xRange = session.getXRange();
+      const chrom = session.getChromosome();
+      return {
+        chrom,
+        start: xRange[0],
+        end: xRange[1],
+      };
+    },
+    true,
+  );
+  return overviewTrack;
+}
+
+export function createDataTrackWrapper(track: DataTrack) {
+  const wrapper = document.createElement("div");
+  wrapper.classList.add("track-wrapper");
+  wrapper.style.position = "relative";
+  wrapper.appendChild(track);
+
+  const handle = document.createElement("div");
+  handle.className = TRACK_HANDLE_CLASS;
+  handle.style.position = "absolute";
+  handle.style.top = "0";
+  handle.style.left = "0";
+  handle.style.width = `${STYLE.yAxis.width}px`;
+  handle.style.height = "100%";
+  wrapper.appendChild(handle);
+
+  return wrapper;
+
+  //   parentContainer.appendChild(wrapper);
+}

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -185,7 +185,6 @@ export function createOverviewTrack(
   chromSizes: Record<string, number>,
   chromClick: (chrom: string) => void,
   session: GensSession,
-  openTrackContextMenu: (track: DataTrack) => void,
 ): OverviewTrack {
   const overviewTrack = new OverviewTrack(
     id,

--- a/assets/js/components/util/choice_select.ts
+++ b/assets/js/components/util/choice_select.ts
@@ -13,8 +13,8 @@ Choices.prototype._onClick = function (event: MouseEvent) {
   // Now, getting the full path where we can check inside the shadow DOM whether
   // the select is clicked
   const path = event.composedPath?.() || [];
-  var containerOuter = this.containerOuter;
-  var clickWasWithinContainer = path.includes(containerOuter.element);
+  const containerOuter = this.containerOuter;
+  const clickWasWithinContainer = path.includes(containerOuter.element);
 
   // Previous line
   // var clickWasWithinContainer = containerOuter.element.contains(target);

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -6,7 +6,7 @@ import "./components/util/choice_select";
 import "./components/side_menu/settings_page";
 import "./components/side_menu/side_menu";
 import "./components/header_info";
-import "./components/util/marker";
+import "./movements/marker";
 import "./components/side_menu/track_page";
 
 import { API } from "./state/api";
@@ -42,7 +42,11 @@ export async function initCanvases({
   const settingsPage = document.createElement("settings-page") as SettingsPage;
 
   const headerInfo = document.getElementById("header-info") as HeaderInfo;
-  headerInfo.initialize(caseId, sampleIds);
+  headerInfo.initialize(
+    caseId,
+    sampleIds,
+    `${scoutBaseURL}/case/case_id/${caseId}`,
+  );
 
   const inputControls = document.getElementById(
     "input-controls",

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -90,7 +90,7 @@ export async function initCanvases({
     return url;
   };
 
-  setupShortcuts(session, sideMenu, inputControls, onChromClick);
+  setupShortcuts(session, sideMenu, inputControls);
 
   const annotSources = await api.getAnnotationSources();
   const defaultAnnot = annotSources
@@ -206,7 +206,6 @@ function setupShortcuts(
   session: GensSession,
   sideMenu: SideMenu,
   inputControls: InputControls,
-  onChromClick: (chrom: string) => void,
 ) {
   // Rebuild the keyboard shortcuts
   document.addEventListener("keydown", (e) => {

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -87,7 +87,10 @@ export async function initCanvases({
     return url;
   };
 
-  const session = new GensSession(render, sideMenu);
+  // FIXME: Input controls should receive region from session
+  // Not the other way around
+  const defaultRegion = {chrom: "1", start: 1, end: 100000};
+  const session = new GensSession(render, sideMenu, defaultRegion);
 
   setupShortcuts(session, sideMenu, inputControls, onChromClick);
 
@@ -196,6 +199,14 @@ async function initialize(
     getCovData: (id: string) => renderDataSource.getCovData(id),
     getBafData: (id: string) => renderDataSource.getBafData(id),
     getVariantData: (id: string) => renderDataSource.getVariantData(id),
+
+    getTranscriptData: () => renderDataSource.getTranscriptData(),
+    getOverviewCovData: (sampleId: string) =>
+      renderDataSource.getOverviewCovData(sampleId),
+    getOverviewBafData: (sampleId: string) =>
+      renderDataSource.getOverviewBafData(sampleId),
+
+    getChromInfo: () => renderDataSource.getChromInfo(),
   };
 
   await tracks.initialize(
@@ -203,16 +214,16 @@ async function initialize(
     sampleIds,
     chromSizes,
     onChromClick,
-    renderDataSource,
-    () => inputControls.getRegion().chrom,
-    () => inputControls.getRange(),
-    (range: Rng) => {
-      console.error("Setting position", range);
-      inputControls.updatePosition(range);
-      render({ dataUpdated: true, positionOnly: true });
-    },
-    () => inputControls.zoomOut(),
-    onPan,
+    // renderDataSource,
+    // () => inputControls.getRegion().chrom,
+    // () => inputControls.getRange(),
+    // (range: Rng) => {
+    //   console.error("Setting position", range);
+    //   inputControls.updatePosition(range);
+    //   render({ dataUpdated: true, positionOnly: true });
+    // },
+    // () => inputControls.zoomOut(),
+    // onPan,
     // (settings: { selectedOnly: boolean }) =>
     //   settingsPage.getAnnotSources(settings),
     tracksDataSources,
@@ -240,7 +251,7 @@ function setupShortcuts(
   // Rebuild the keyboard shortcuts
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape") {
-      if (session.getMarkerMode()) {
+      if (session.getMarkerModeOn()) {
         inputControls.toggleMarkerMode();
         return;
       }

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -1,4 +1,4 @@
-import "./components/tracks_manager";
+import "./components/tracks_manager/tracks_manager";
 import "./components/input_controls";
 import "./components/util/popup";
 import "./components/util/shadowbaseelement";
@@ -10,7 +10,7 @@ import "./movements/marker";
 import "./components/side_menu/track_page";
 
 import { API } from "./state/api";
-import { TracksManager } from "./components/tracks_manager";
+import { TracksManager } from "./components/tracks_manager/tracks_manager";
 import { InputControls } from "./components/input_controls";
 import { getRenderDataSource } from "./state/parse_data";
 import { CHROMOSOMES } from "./constants";

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -18,7 +18,6 @@ import { SideMenu } from "./components/side_menu/side_menu";
 import { SettingsPage } from "./components/side_menu/settings_page";
 import { HeaderInfo } from "./components/header_info";
 import { GensSession } from "./state/gens_session";
-import { chromSizes } from "./unused/_helper";
 
 export async function initCanvases({
   caseId,
@@ -62,25 +61,6 @@ export async function initCanvases({
     inputControls.render(settings);
   };
 
-
-  // const getChromSize = (chrom: string) => api.getChromData(chrom);
-
-  // const allChromData: Record<string, ChromosomeInfo> = {};
-  // for (const chrom of CHROMOSOMES) {
-  //   const chromInfo = await api.getChromData(chrom);
-  //   allChromData[chrom] = chromInfo;
-  // }
-
-  // const allChromSizes: Record<string, number> = {};
-  // for (const chrom of CHROMOSOMES) {
-  //   const chromLength = allChromData[chrom].size;
-  //   allChromSizes[chrom] = chromLength;
-  // }
-
-  // FIXME: First get all the sizes
-
-  // FIXME: Input controls should receive region from session
-  // Not the other way around
   const chromSizes = api.getChromSizes();
   const defaultRegion = { chrom: "1", start: 1, end: chromSizes["1"] };
   const session = new GensSession(
@@ -97,7 +77,6 @@ export async function initCanvases({
   );
 
   const onChromClick = async (chrom) => {
-    // const chromData = await api.getChromData(chrom);
     session.updateChromosome(chrom);
     render({ dataUpdated: true });
   };
@@ -216,28 +195,7 @@ async function initialize(
     sampleIds,
     chromSizes,
     onChromClick,
-    // renderDataSource,
-    // () => inputControls.getRegion().chrom,
-    // () => inputControls.getRange(),
-    // (range: Rng) => {
-    //   console.error("Setting position", range);
-    //   inputControls.updatePosition(range);
-    //   render({ dataUpdated: true, positionOnly: true });
-    // },
-    // () => inputControls.zoomOut(),
-    // onPan,
-    // (settings: { selectedOnly: boolean }) =>
-    //   settingsPage.getAnnotSources(settings),
     tracksDataSources,
-    // getVariantURL,
-    // async (id: string) => await api.getAnnotationDetails(id),
-    // async (id: string) => await api.getTranscriptDetails(id),
-    // async (sampleId: string, variantId: string) =>
-    //   await api.getVariantDetails(
-    //     sampleId,
-    //     variantId,
-    //     inputControls.getRegion().chrom,
-    //   ),
     session,
   );
 

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -187,16 +187,6 @@ async function initialize(
     render({ dataUpdated: true, positionOnly: true });
   });
 
-  const onPan = (panDistance: number) => {
-    const startRange = session.getXRange();
-    const currChromLength = chromSizes[session.getChromosome()];
-    const endRange: Rng = [
-      Math.max(0, Math.floor(startRange[0] - panDistance)),
-      Math.min(Math.floor(startRange[1] - panDistance), currChromLength),
-    ];
-    session.setViewRange(endRange);
-    render({ dataUpdated: true, positionOnly: true });
-  };
 
   const tracksDataSources = {
     getAnnotationSources: (settings: { selectedOnly: boolean }) =>

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -217,36 +217,37 @@ function setupShortcuts(
       }
       sideMenu.close();
     }
-    if (e.key === "ArrowLeft") {
-      if (e.ctrlKey || e.metaKey) {
-        const currChrom = session.getChromosome();
-        const currIndex = CHROMOSOMES.indexOf(currChrom);
-        if (currIndex > 0) {
-          const newChrom = CHROMOSOMES[currIndex - 1];
-          onChromClick(newChrom);
-        }
-      } else {
-        inputControls.panLeft();
-      }
-    }
-    if (e.key === "ArrowRight") {
-      if (e.ctrlKey || e.metaKey) {
-        const currChrom = session.getChromosome();
-        const currIndex = CHROMOSOMES.indexOf(currChrom);
-        if (currIndex < CHROMOSOMES.length - 1) {
-          const newChrom = CHROMOSOMES[currIndex + 1];
-          onChromClick(newChrom);
-        }
-      } else {
-        inputControls.panRight();
-      }
-    }
-    if (e.key === "ArrowUp") {
-      inputControls.zoomIn();
-    }
-    if (e.key === "ArrowDown") {
-      inputControls.zoomOut();
-    }
+    // FIXME: Restore these, should not be active when for instance cursor is inside region box
+    // if (e.key === "ArrowLeft") {
+    //   if (e.ctrlKey || e.metaKey) {
+    //     const currChrom = session.getChromosome();
+    //     const currIndex = CHROMOSOMES.indexOf(currChrom);
+    //     if (currIndex > 0) {
+    //       const newChrom = CHROMOSOMES[currIndex - 1];
+    //       onChromClick(newChrom);
+    //     }
+    //   } else {
+    //     inputControls.panLeft();
+    //   }
+    // }
+    // if (e.key === "ArrowRight") {
+    //   if (e.ctrlKey || e.metaKey) {
+    //     const currChrom = session.getChromosome();
+    //     const currIndex = CHROMOSOMES.indexOf(currChrom);
+    //     if (currIndex < CHROMOSOMES.length - 1) {
+    //       const newChrom = CHROMOSOMES[currIndex + 1];
+    //       onChromClick(newChrom);
+    //     }
+    //   } else {
+    //     inputControls.panRight();
+    //   }
+    // }
+    // if (e.key === "ArrowUp") {
+    //   inputControls.zoomIn();
+    // }
+    // if (e.key === "ArrowDown") {
+    //   inputControls.zoomOut();
+    // }
     if (e.key === "r") {
       inputControls.resetZoom();
     }

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -190,7 +190,7 @@ async function initialize(
     getChromInfo: () => renderDataSource.getChromInfo(),
   };
 
-  await tracks.initialize(
+  tracks.initialize(
     render,
     sampleIds,
     chromSizes,

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -168,6 +168,36 @@ async function initialize(
     session,
   );
 
+  const onPan = (panDistance: number) => {
+    const startRange = inputControls.getRange();
+    const currChromLength = chromSizes[inputControls.getRegion().chrom];
+    const endRange: Rng = [
+      Math.max(0, Math.floor(startRange[0] - panDistance)),
+      Math.min(Math.floor(startRange[1] - panDistance), currChromLength),
+    ];
+    inputControls.updatePosition(endRange);
+    render({ dataUpdated: true, positionOnly: true });
+  };
+
+  const tracksDataSources = {
+    getAnnotationSources: (settings: { selectedOnly: boolean }) =>
+      settingsPage.getAnnotSources(settings),
+    getVariantUrl: (id: string) => getVariantURL(id),
+    getAnnotationDetails: (id: string) => api.getAnnotationDetails(id),
+    getTranscriptDetails: (id: string) => api.getTranscriptDetails(id),
+    getVariantDetails: (sampleId: string, variantId: string) =>
+      api.getVariantDetails(
+        sampleId,
+        variantId,
+        inputControls.getRegion().chrom,
+      ),
+
+    getAnnotation: (id: string) => renderDataSource.getAnnotation(id),
+    getCovData: (id: string) => renderDataSource.getCovData(id),
+    getBafData: (id: string) => renderDataSource.getBafData(id),
+    getVariantData: (id: string) => renderDataSource.getVariantData(id),
+  };
+
   await tracks.initialize(
     render,
     sampleIds,
@@ -177,31 +207,24 @@ async function initialize(
     () => inputControls.getRegion().chrom,
     () => inputControls.getRange(),
     (range: Rng) => {
+      console.error("Setting position", range);
       inputControls.updatePosition(range);
       render({ dataUpdated: true, positionOnly: true });
     },
     () => inputControls.zoomOut(),
-    (pan: number) => {
-      const startRange = inputControls.getRange();
-      const currChromLength = chromSizes[inputControls.getRegion().chrom];
-      const endRange: Rng = [
-        Math.max(0, Math.floor(startRange[0] - pan)),
-        Math.min(Math.floor(startRange[1] - pan), currChromLength),
-      ];
-      inputControls.updatePosition(endRange);
-      render({ dataUpdated: true, positionOnly: true });
-    },
-    (settings: { selectedOnly: boolean }) =>
-      settingsPage.getAnnotSources(settings),
-    getVariantURL,
-    async (id: string) => await api.getAnnotationDetails(id),
-    async (id: string) => await api.getTranscriptDetails(id),
-    async (sampleId: string, variantId: string) =>
-      await api.getVariantDetails(
-        sampleId,
-        variantId,
-        inputControls.getRegion().chrom,
-      ),
+    onPan,
+    // (settings: { selectedOnly: boolean }) =>
+    //   settingsPage.getAnnotSources(settings),
+    tracksDataSources,
+    // getVariantURL,
+    // async (id: string) => await api.getAnnotationDetails(id),
+    // async (id: string) => await api.getTranscriptDetails(id),
+    // async (sampleId: string, variantId: string) =>
+    //   await api.getVariantDetails(
+    //     sampleId,
+    //     variantId,
+    //     inputControls.getRegion().chrom,
+    //   ),
     session,
   );
 

--- a/assets/js/movements/dragging.ts
+++ b/assets/js/movements/dragging.ts
@@ -1,7 +1,6 @@
 import { initializeDragSelect } from "../components/tracks/base_tracks/interactive_tools";
-import { COLORS, STYLE } from "../constants";
+import { STYLE } from "../constants";
 import { getLinearScale } from "../draw/render_utils";
-import { generateID } from "../util/utils";
 
 // FIXME: Both needed? Probably not
 export function setupDrag(
@@ -12,7 +11,6 @@ export function setupDrag(
   onSetViewRange: (range: Rng) => void,
   onAddHighlight: (range: Rng) => void,
   onRemoveHighlight: (id: string) => void,
-  // dragCallbacks: DragCallbacks,
 ) {
   const onDragEnd = (pxRangeX: Rng, _pxRangeY: Rng, shiftPress: boolean) => {
     const xRange = getXRange();

--- a/assets/js/movements/dragging.ts
+++ b/assets/js/movements/dragging.ts
@@ -44,10 +44,8 @@ export function setupDragging(
   onDragEnd: (range: Rng) => void,
 ) {
   let dragStartX: number | null = null;
-  let dragEndX: number | null = null;
 
   let isSpaceDown = false;
-  let isMouseDown = false;
   window.addEventListener("keydown", (event) => {
     if (event.code === "Space") {
       isSpaceDown = true;
@@ -66,7 +64,6 @@ export function setupDragging(
   });
 
   container.addEventListener("pointerdown", (event) => {
-    isMouseDown = true;
 
     if (isSpaceDown) {
       dragStartX = event.offsetX;
@@ -76,7 +73,6 @@ export function setupDragging(
   });
 
   container.addEventListener("pointerup", (event) => {
-    isMouseDown = false;
 
     if (event.button === 0 && isSpaceDown) {
       const dragEndX = event.offsetX;
@@ -90,6 +86,5 @@ export function setupDragging(
     }
 
     dragStartX = null;
-    dragEndX = null;
   });
 }

--- a/assets/js/movements/dragging.ts
+++ b/assets/js/movements/dragging.ts
@@ -37,7 +37,7 @@ export function setupDragging(
   container.addEventListener("pointerup", (event) => {
     isMouseDown = false;
 
-    if (event.button === 0) {
+    if (event.button === 0 && isSpaceDown) {
       const dragEndX = event.offsetX;
 
       container.releasePointerCapture(event.pointerId);

--- a/assets/js/movements/dragging.ts
+++ b/assets/js/movements/dragging.ts
@@ -1,3 +1,46 @@
+import { initializeDragSelect } from "../components/tracks/base_tracks/interactive_tools";
+import { COLORS, STYLE } from "../constants";
+import { getLinearScale } from "../draw/render_utils";
+import { generateID } from "../util/utils";
+
+// FIXME: Both needed? Probably not
+export function setupDrag(
+  tracksContainer: HTMLElement,
+  getMarkerModeOn: () => boolean,
+  getXRange: () => Rng,
+  getChromosome: () => string,
+  onSetViewRange: (range: Rng) => void,
+  onAddHighlight: (range: Rng) => void,
+  onRemoveHighlight: (id: string) => void,
+  // dragCallbacks: DragCallbacks,
+) {
+  const onDragEnd = (pxRangeX: Rng, _pxRangeY: Rng, shiftPress: boolean) => {
+    const xRange = getXRange();
+    if (xRange == null) {
+      console.error("No xRange set");
+    }
+
+    const yAxisWidth = STYLE.yAxis.width;
+
+    const pixelToPos = getLinearScale(
+      [yAxisWidth, tracksContainer.offsetWidth],
+      xRange,
+    );
+    const posStart = pixelToPos(Math.max(yAxisWidth, pxRangeX[0]));
+    const posEnd = pixelToPos(Math.max(yAxisWidth, pxRangeX[1]));
+
+    if (shiftPress) {
+      onSetViewRange([Math.floor(posStart), Math.floor(posEnd)]);
+    } else {
+      onAddHighlight([posStart, posEnd]);
+    }
+  };
+
+  initializeDragSelect(tracksContainer, onDragEnd, onRemoveHighlight, () =>
+    getMarkerModeOn(),
+  );
+}
+
 export function setupDragging(
   container: HTMLElement,
   onDragEnd: (range: Rng) => void,

--- a/assets/js/movements/dragging.ts
+++ b/assets/js/movements/dragging.ts
@@ -7,12 +7,12 @@ export function setupDrag(
   tracksContainer: HTMLElement,
   getMarkerModeOn: () => boolean,
   getXRange: () => Rng,
-  getChromosome: () => string,
   onSetViewRange: (range: Rng) => void,
   onAddHighlight: (range: Rng) => void,
   onRemoveHighlight: (id: string) => void,
 ) {
   const onDragEnd = (pxRangeX: Rng, _pxRangeY: Rng, shiftPress: boolean) => {
+
     const xRange = getXRange();
     if (xRange == null) {
       console.error("No xRange set");

--- a/assets/js/movements/marker.ts
+++ b/assets/js/movements/marker.ts
@@ -1,6 +1,6 @@
-import { SIZES, STYLE } from "../../constants";
-import { rangeSize, sortRange } from "../../util/utils";
-import { ShadowBaseElement } from "./shadowbaseelement";
+import { ShadowBaseElement } from "../components/util/shadowbaseelement";
+import { SIZES, STYLE } from "../constants";
+import { rangeSize, sortRange } from "../util/utils";
 
 const style = STYLE.menu;
 

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -1,3 +1,4 @@
+import { CHROMOSOMES } from "../constants";
 import { get } from "../util/fetch";
 import { zip } from "../util/utils";
 
@@ -11,10 +12,41 @@ export class API {
   // Remaining zoom levels (up to "d") are loaded dynamically and
   // only for the points currently in view
 
+  private allChromData: Record<string, ChromosomeInfo> = {};
+
+  // getChromData(chrom: string): ChromosomeInfo {
+  //   if (this.allChromData == null) {
+  //     throw Error("Must initialize before accessing the chromosome info");
+  //   }
+  //   return this.allChromData[chrom];
+  // }
+
+  getChromSizes(): Record<string, number> {
+
+    if (this.allChromData == null) {
+      throw Error("Must initialize before accessing the chromosome sizes");
+    }
+
+    const allChromSizes = {};
+    for (const chrom of CHROMOSOMES) {
+      const chromLength = this.allChromData[chrom].size;
+      allChromSizes[chrom] = chromLength;
+    }
+    return allChromSizes;
+  }
+
   constructor(caseId: string, genomeBuild: number, gensApiURL: string) {
     this.caseId = caseId;
     this.genomeBuild = genomeBuild;
     this.apiURI = gensApiURL;
+  }
+
+  async initialize() {
+    console.log("initializing");
+    for (const chrom of CHROMOSOMES) {
+      const chromInfo = await this.getChromData(chrom);
+      this.allChromData[chrom] = chromInfo;
+    }
   }
 
   getAnnotationDetails(id: string): Promise<ApiAnnotationDetails> {
@@ -104,6 +136,7 @@ export class API {
           sampleId,
           this.caseId,
           this.apiURI,
+          this.getChromSizes(),
         );
       }
       return this.covSampleChrZoomCache[sampleId][chrom][zoom];
@@ -147,6 +180,7 @@ export class API {
           sampleId,
           this.caseId,
           this.apiURI,
+          this.getChromSizes()
         );
       }
       return this.bafSampleZoomChrCache[sampleId][chrom][zoom];
@@ -270,27 +304,16 @@ async function getCovData(
   caseId: string,
   chrom: string,
   zoom: string,
-  range?: Rng,
+  range: Rng,
 ): Promise<ApiCoverageDot[]> {
-  let query;
-  if (range != null) {
-    query = {
-      sample_id: sampleId,
-      case_id: caseId,
-      chromosome: chrom,
-      zoom_level: zoom,
-      start: range[0],
-      end: range[1],
-    };
-  } else {
-    query = {
-      sample_id: sampleId,
-      case_id: caseId,
-      chromosome: chrom,
-      zoom_level: zoom,
-      start: 1,
-    };
-  }
+  const query = {
+    sample_id: sampleId,
+    case_id: caseId,
+    chromosome: chrom,
+    zoom_level: zoom,
+    start: range[0],
+    end: range[1],
+  };
 
   const regionResult = (await get(new URL(endpoint, apiURI).href, query)) as {
     position: number[];
@@ -316,6 +339,7 @@ function getDataPerZoom(
   sampleId: string,
   caseId: string,
   apiURI: string,
+  chromSizes: Record<string, number>,
 ): Record<string, Promise<ApiCoverageDot[]>> {
   const dataPerZoom: Record<string, Promise<ApiCoverageDot[]>> = {};
 
@@ -327,6 +351,7 @@ function getDataPerZoom(
       caseId,
       chrom,
       zoom,
+      [1, chromSizes[chrom]],
     );
     dataPerZoom[zoom] = parsedResult;
   }

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -35,7 +35,6 @@ export class API {
   }
 
   async initialize() {
-    console.log("initializing");
     for (const chrom of CHROMOSOMES) {
       const chromInfo = await this.getChromData(chrom);
       this.allChromData[chrom] = chromInfo;

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -14,13 +14,6 @@ export class API {
 
   private allChromData: Record<string, ChromosomeInfo> = {};
 
-  // getChromData(chrom: string): ChromosomeInfo {
-  //   if (this.allChromData == null) {
-  //     throw Error("Must initialize before accessing the chromosome info");
-  //   }
-  //   return this.allChromData[chrom];
-  // }
-
   getChromSizes(): Record<string, number> {
 
     if (this.allChromData == null) {

--- a/assets/js/state/gens_session.ts
+++ b/assets/js/state/gens_session.ts
@@ -33,8 +33,6 @@ export class GensSession {
     chromSizes: Record<string, number>
   ) {
 
-    console.log("Assigning region", region);
-
     this.render = render;
     this.sideMenu = sideMenu;
     this.highlights = {};

--- a/assets/js/state/gens_session.ts
+++ b/assets/js/state/gens_session.ts
@@ -15,7 +15,6 @@ import { generateID } from "../util/utils";
  * it should probably be kept here as well.
  */
 export class GensSession {
-  // FIXME: Could / should the region be in there? Yes.
   chromosome: string;
   start: number;
   end: number;
@@ -57,10 +56,6 @@ export class GensSession {
       end: this.end,
     }
   }
-
-  // getRange(): Rng {
-  //   return [this.start, this.end] as Rng;
-  // }
 
   updateChromosome(chrom: string) {
     this.chromosome = chrom;

--- a/assets/js/state/gens_session.ts
+++ b/assets/js/state/gens_session.ts
@@ -84,6 +84,19 @@ export class GensSession {
     return this.markerModeOn;
   }
 
+  /**
+   * Distance can be negative
+   */
+  moveXRange(distance: number): void {
+    const startRange = this.getXRange();
+    const chromSize = this.getCurrentChromSize();
+    const newRange: Rng = [
+      Math.max(0, Math.floor(startRange[0] + distance)),
+      Math.min(Math.floor(startRange[1] + distance), chromSize),
+    ];
+    this.setViewRange(newRange);
+  }
+
   toggleMarkerMode() {
     this.markerModeOn = !this.markerModeOn;
     this.render({});

--- a/assets/js/state/gens_session.ts
+++ b/assets/js/state/gens_session.ts
@@ -46,7 +46,8 @@ export class GensSession {
   }
 
   setViewRange(range: Rng): void {
-    console.log("on zoom in");
+    this.start = range[0];
+    this.end = range[1];
   }
 
   getRegion(): Region {
@@ -72,20 +73,16 @@ export class GensSession {
     this.end = range[1];
   }
 
-  zoomOut(): void {
-    console.log("on zoom out");
-  }
-
-  onPan(panX: number): void {
-    console.log("on pan");
-  }
-
   getChromosome(): string {
     return this.chromosome;
   }
 
   getXRange(): Rng {
     return [this.start, this.end] as Rng;
+  }
+
+  getCurrentChromSize(): number {
+    return this.chromSizes[this.chromosome];
   }
 
   getMarkerModeOn(): boolean {

--- a/assets/js/state/gens_session.ts
+++ b/assets/js/state/gens_session.ts
@@ -25,21 +25,51 @@ export class GensSession {
   private markerModeOn: boolean = false;
   private highlights: Record<string, RangeHighlight>;
 
+  private chromSizes: Record<string, number>;
+
   constructor(
     render: (settings: RenderSettings) => void,
     sideMenu: SideMenu,
     region: Region,
+    chromSizes: Record<string, number>
   ) {
+
+    console.log("Assigning region", region);
+
     this.render = render;
     this.sideMenu = sideMenu;
     this.highlights = {};
     this.chromosome = region.chrom;
     this.start = region.start;
     this.end = region.end;
+    this.chromSizes = chromSizes;
   }
 
   setViewRange(range: Rng): void {
     console.log("on zoom in");
+  }
+
+  getRegion(): Region {
+    return {
+      chrom: this.chromosome,
+      start: this.start,
+      end: this.end,
+    }
+  }
+
+  // getRange(): Rng {
+  //   return [this.start, this.end] as Rng;
+  // }
+
+  updateChromosome(chrom: string) {
+    this.chromosome = chrom;
+    this.start = 1;
+    this.end = this.chromSizes[chrom];
+  }
+
+  updatePosition(range: Rng): void {
+    this.start = range[0];
+    this.end = range[1];
   }
 
   zoomOut(): void {

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -37,8 +37,6 @@ export function getRenderDataSource(
   const getCovData = async (sampleId: string) => {
     const xRange = getXRange();
 
-    console.log("Hello world");
-
     const zoom = calculateZoom(xRange);
 
     const covRaw = await gensAPI.getCov(sampleId, getChrom(), zoom, xRange);

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -26,7 +26,6 @@ export function getRenderDataSource(
 ): RenderDataSource {
   const getChromInfo = async () => {
     return gensAPI.getChromData(getChrom());
-    // return await gensAPI.getChromData(getChrom());
   };
 
   const getAnnotation = async (recordId: string) => {
@@ -36,7 +35,6 @@ export function getRenderDataSource(
 
   const getCovData = async (sampleId: string) => {
     const xRange = getXRange();
-
     const zoom = calculateZoom(xRange);
 
     const covRaw = await gensAPI.getCov(sampleId, getChrom(), zoom, xRange);

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -25,7 +25,8 @@ export function getRenderDataSource(
   getXRange: () => Rng,
 ): RenderDataSource {
   const getChromInfo = async () => {
-    return await gensAPI.getChromData(getChrom());
+    return gensAPI.getChromData(getChrom());
+    // return await gensAPI.getChromData(getChrom());
   };
 
   const getAnnotation = async (recordId: string) => {
@@ -35,6 +36,9 @@ export function getRenderDataSource(
 
   const getCovData = async (sampleId: string) => {
     const xRange = getXRange();
+
+    console.log("Hello world");
+
     const zoom = calculateZoom(xRange);
 
     const covRaw = await gensAPI.getCov(sampleId, getChrom(), zoom, xRange);

--- a/assets/js/state/session.ts
+++ b/assets/js/state/session.ts
@@ -1,4 +1,6 @@
 import { SideMenu } from "../components/side_menu/side_menu";
+import { COLORS } from "../constants";
+import { generateID } from "../util/utils";
 
 /**
  * The purpose of this class is to keep track of the web session,
@@ -14,28 +16,55 @@ import { SideMenu } from "../components/side_menu/side_menu";
  */
 export class GensSession {
   // FIXME: Could / should the region be in there? Yes.
-  // chromosome: string;
-  // start: number;
-  // end: number;
+  chromosome: string;
+  start: number;
+  end: number;
+
+  private render: (settings: RenderSettings) => void;
+  private sideMenu: SideMenu;
   private markerModeOn: boolean = false;
   private highlights: Record<string, RangeHighlight>;
 
-  getMarkerMode(): boolean {
+  constructor(
+    render: (settings: RenderSettings) => void,
+    sideMenu: SideMenu,
+    region: Region,
+  ) {
+    this.render = render;
+    this.sideMenu = sideMenu;
+    this.highlights = {};
+    this.chromosome = region.chrom;
+    this.start = region.start;
+    this.end = region.end;
+  }
+
+  setViewRange(range: Rng): void {
+    console.log("on zoom in");
+  }
+
+  zoomOut(): void {
+    console.log("on zoom out");
+  }
+
+  onPan(panX: number): void {
+    console.log("on pan");
+  }
+
+  getChromosome(): string {
+    return this.chromosome;
+  }
+
+  getXRange(): Rng {
+    return [this.start, this.end] as Rng;
+  }
+
+  getMarkerModeOn(): boolean {
     return this.markerModeOn;
   }
 
   toggleMarkerMode() {
     this.markerModeOn = !this.markerModeOn;
     this.render({});
-  }
-
-  private render: (settings: RenderSettings) => void;
-  private sideMenu: SideMenu;
-
-  constructor(render: (settings: RenderSettings) => void, sideMenu: SideMenu) {
-    this.render = render;
-    this.sideMenu = sideMenu;
-    this.highlights = {};
   }
 
   showContent(header: string, content: HTMLElement[]) {
@@ -45,13 +74,31 @@ export class GensSession {
   getHighlights(chrom: string): RangeHighlight[] {
     return Object.values(this.highlights).filter((h) => h.chromosome === chrom);
   }
+
+  /**
+   * Return highlights for the currently viewed chromosome
+   */
+  getCurrentHighlights(): RangeHighlight[] {
+    return this.getHighlights(this.chromosome);
+  }
+
   removeHighlights() {
     this.highlights = {};
     this.render({});
   }
-  addHighlight(highlight: RangeHighlight) {
+  addHighlight(range: Rng): string {
+    const id = generateID();
+
+    const highlight = {
+      id,
+      chromosome: this.chromosome,
+      range,
+      color: COLORS.transparentBlue,
+    };
+
     this.highlights[highlight.id] = highlight;
     this.render({});
+    return id;
   }
   removeHighlight(id: string) {
     delete this.highlights[id];

--- a/assets/js/util/navigation.ts
+++ b/assets/js/util/navigation.ts
@@ -22,17 +22,12 @@ export function getPan(
   return [newStartX, newEndX];
 }
 
-// FIXME: Maybe in session instead?
 export function calculatePan(panDistance: number, startRange: Rng, chromSize: number) {
-  // const startRange = session.getXRange();
-  // const currChromLength = chromSizes[session.getChromosome()];
   const endRange: Rng = [
     Math.max(0, Math.floor(startRange[0] - panDistance)),
     Math.min(Math.floor(startRange[1] - panDistance), chromSize),
   ];
   return endRange;
-  // session.setViewRange(endRange);
-  // render({ dataUpdated: true, positionOnly: true });
 }
 
 // parse chromosomal region designation string
@@ -77,5 +72,4 @@ export function zoomOut(
   newEnd = Math.min(newEnd, maxX);
 
   return [newStart, newEnd];
-  // pos.end += factor;
 }

--- a/assets/js/util/navigation.ts
+++ b/assets/js/util/navigation.ts
@@ -1,26 +1,38 @@
 import { CHROMOSOMES } from "../constants";
 
 export function getPan(
-    viewRange: [number, number],
-    direction = "left",
-    speed = 0.1,
+  viewRange: [number, number],
+  direction = "left",
+  edge: number,
+  speed = 0.1,
 ): [number, number] {
-    const distance = Math.abs(Math.floor(speed * (viewRange[1] - viewRange[0])));
-    let newStartX;
-    let newEndX;
-    if (direction === "left") {
-        newStartX = viewRange[0] - distance;
-        newEndX = viewRange[1] - distance;
-    } else {
-        newStartX = viewRange[0] + distance;
-        newEndX = viewRange[1] + distance;
-    }
-    // drawTrack will correct the window eventually, but let us not go negative at least
-    if (newStartX < 1) {
-        newStartX = newEndX - newStartX;
-        newStartX = 1;
-    }
-    return [newStartX, newEndX];
+  const distance = Math.abs(Math.floor(speed * (viewRange[1] - viewRange[0])));
+  let newStartX;
+  let newEndX;
+  if (direction === "left") {
+    // Stop at the left edge
+    newStartX = Math.max(edge, viewRange[0] - distance);
+    newEndX = viewRange[1] - distance;
+  } else {
+    newStartX = viewRange[0] + distance;
+    // Stop at the right edge
+    newEndX = Math.min(viewRange[1] + distance, edge);
+  }
+
+  return [newStartX, newEndX];
+}
+
+// FIXME: Maybe in session instead?
+export function calculatePan(panDistance: number, startRange: Rng, chromSize: number) {
+  // const startRange = session.getXRange();
+  // const currChromLength = chromSizes[session.getChromosome()];
+  const endRange: Rng = [
+    Math.max(0, Math.floor(startRange[0] - panDistance)),
+    Math.min(Math.floor(startRange[1] - panDistance), chromSize),
+  ];
+  return endRange;
+  // session.setViewRange(endRange);
+  // render({ dataUpdated: true, positionOnly: true });
 }
 
 // parse chromosomal region designation string
@@ -29,36 +41,41 @@ export function getPan(
 // 1: --> 1, null, null
 // 1 --> 1, null, null
 export function parseRegionDesignation(regionString) {
-    if (regionString.includes(":")) {
-        const [chromosome, position] = regionString.split(":");
-        // verify chromosome
-        if (!CHROMOSOMES.includes(chromosome)) {
-            throw new Error(`${chromosome} is not a valid chromosome`);
-        }
-        let [start, end] = position.split("-");
-        start = parseInt(start);
-        end = parseInt(end);
-        return { chrom: chromosome, start: start, end: end };
+  if (regionString.includes(":")) {
+    const [chromosome, position] = regionString.split(":");
+    // verify chromosome
+    if (!CHROMOSOMES.includes(chromosome)) {
+      throw new Error(`${chromosome} is not a valid chromosome`);
     }
+    let [start, end] = position.split("-");
+    start = parseInt(start);
+    end = parseInt(end);
+    return { chrom: chromosome, start: start, end: end };
+  }
 }
 
 export function zoomIn(
-    xCurrView: [number, number],
-    zoomFactor: number = 0.2,
+  xCurrView: [number, number],
+  zoomFactor: number = 0.2,
 ): [number, number] {
-    const factor = Math.floor((xCurrView[1] - xCurrView[0]) * zoomFactor);
-    const newStart = xCurrView[0] + factor;
-    const newEnd = xCurrView[1] - factor;
-    return [newStart, newEnd];
+  const factor = Math.floor((xCurrView[1] - xCurrView[0]) * zoomFactor);
+  const newStart = xCurrView[0] + factor;
+  const newEnd = xCurrView[1] - factor;
+  return [newStart, newEnd];
 }
 
 export function zoomOut(
-    xCurrView: [number, number],
-    zoomFactor: number = 3,
+  xCurrView: [number, number],
+  maxX: number,
+  zoomFactor: number = 3,
 ): [number, number] {
-    const factor = Math.floor((xCurrView[1] - xCurrView[0]) / zoomFactor);
-    const newStart = xCurrView[0] - factor < 1 ? 1 : xCurrView[0] - factor;
-    const newEnd = xCurrView[1] + factor;
-    return [newStart, newEnd];
-    // pos.end += factor;
+  const factor = Math.floor((xCurrView[1] - xCurrView[0]) / zoomFactor);
+  let newStart = xCurrView[0] - factor < 1 ? 1 : xCurrView[0] - factor;
+  let newEnd = xCurrView[1] + factor;
+
+  newStart = Math.max(0, newStart);
+  newEnd = Math.min(newEnd, maxX);
+
+  return [newStart, newEnd];
+  // pos.end += factor;
 }

--- a/assets/js/util/navigation.ts
+++ b/assets/js/util/navigation.ts
@@ -22,14 +22,6 @@ export function getPan(
   return [newStartX, newEndX];
 }
 
-// export function calculatePan(panDistance: number, startRange: Rng, chromSize: number) {
-//   const endRange: Rng = [
-//     Math.max(0, Math.floor(startRange[0] - panDistance)),
-//     Math.min(Math.floor(startRange[1] - panDistance), chromSize),
-//   ];
-//   return endRange;
-// }
-
 // parse chromosomal region designation string
 // return chromosome, start and end position
 // eg 1:12-220 --> 1, 12 220

--- a/assets/js/util/navigation.ts
+++ b/assets/js/util/navigation.ts
@@ -22,13 +22,13 @@ export function getPan(
   return [newStartX, newEndX];
 }
 
-export function calculatePan(panDistance: number, startRange: Rng, chromSize: number) {
-  const endRange: Rng = [
-    Math.max(0, Math.floor(startRange[0] - panDistance)),
-    Math.min(Math.floor(startRange[1] - panDistance), chromSize),
-  ];
-  return endRange;
-}
+// export function calculatePan(panDistance: number, startRange: Rng, chromSize: number) {
+//   const endRange: Rng = [
+//     Math.max(0, Math.floor(startRange[0] - panDistance)),
+//     Math.min(Math.floor(startRange[1] - panDistance), chromSize),
+//   ];
+//   return endRange;
+// }
 
 // parse chromosomal region designation string
 // return chromosome, start and end position

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -282,12 +282,13 @@ export function populateSelect(
     opt.value = id;
     opt.innerHTML = label;
     return opt;
-  }
+  };
 
   if (includeNoSelect) {
-    select.appendChild(getOption("", "---"));    
+    select.appendChild(getOption("", "---"));
   }
   for (const option of options) {
     select.appendChild(getOption(option.id, option.label));
   }
 }
+


### PR DESCRIPTION
The tracks manager class was gradually growing beyond control. This is an attempt to tame it 🪴 

Expands the session class, by among other moving the current view state (i.e. chromosome, start, end) to it instead of the input controls in the top bar.

Also adds a Scout URL case link to the top bar.

It is kind of a good PR to look at to see whether you agree / disagree with the currently preferred TS style in Gens.
