### PR TITLE
Quick post-meeting fixes

### DIFF
--- a/assets/js/components/header_info.ts
+++ b/assets/js/components/header_info.ts
@@ -6,8 +6,8 @@ template.innerHTML = String.raw`
 <style>
   #container {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    flex-direction: row;
+    align-items: center;
     height: 100%;
     padding-left: ${SIZES.s}px;
   }
@@ -17,30 +17,37 @@ template.innerHTML = String.raw`
     padding-top: ${SIZES.xs}px;
     justify-content: space-between;
   }
+  .col {
+    display: flex;
+    flex-direction: column;
+  }
   .text {
-    font-size: ${FONT_SIZE.medium}px;
+    font-size: ${FONT_SIZE.large}px;
     color: ${COLORS.darkGray};
   }
   .label {
     font-weight: ${FONT_WEIGHT.header};
     padding-right: ${SIZES.xs}px;
   }
+  a {
+    color: ${COLORS.darkGray}
+  }
 </style>
 <div id="container">
-  <div class="row text">
-    <div class="label">Case </div>
-    <a href="" id="case-id" target="_blank">(value)</a>
-  </div>
-  <div class="row text">
-    <div class="label">Sample </div>
-    <div id="sample-ids">(value)</div>
+
+  <div class="col text">
+    <div title="Gens version" class="label" id="version">Version</div>
+    <a title="Case ID" href="" id="case-id" target="_blank">(value)</a>
+    <!-- &nbsp; -->
+    <!-- <div title="Sample IDs">(<span id="sample-ids">(value)</span>)</div> -->
   </div>
 </div>
 `;
 
 export class HeaderInfo extends ShadowBaseElement {
   private caseIdElem: HTMLAnchorElement;
-  private sampleIdsElem: HTMLDivElement;
+  // private sampleIdsElem: HTMLDivElement;
+  private versionElem: HTMLDivElement;
 
   constructor() {
     super(template);
@@ -48,17 +55,20 @@ export class HeaderInfo extends ShadowBaseElement {
 
   connectedCallback(): void {
     this.caseIdElem = this.root.querySelector("#case-id");
-    this.sampleIdsElem = this.root.querySelector("#sample-ids");
+    // this.sampleIdsElem = this.root.querySelector("#sample-ids");
+    this.versionElem = this.root.querySelector("#version");
   }
 
   initialize(
     caseId: string,
     sampleIds: string[],
     caseURL: string,
+    version: string,
   ) {
     this.caseIdElem.innerHTML = caseId;
     this.caseIdElem.href = caseURL;
-    this.sampleIdsElem.innerHTML = sampleIds.join(", ");
+    // this.sampleIdsElem.innerHTML = sampleIds.join(", ");
+    this.versionElem.innerHTML = version;
   }
 }
 

--- a/assets/js/components/header_info.ts
+++ b/assets/js/components/header_info.ts
@@ -38,8 +38,6 @@ template.innerHTML = String.raw`
   <div class="col text">
     <div title="Gens version" class="label" id="version">Version</div>
     <a title="Case ID" href="" id="case-id" target="_blank">(value)</a>
-    <!-- &nbsp; -->
-    <!-- <div title="Sample IDs">(<span id="sample-ids">(value)</span>)</div> -->
   </div>
 </div>
 `;
@@ -61,7 +59,7 @@ export class HeaderInfo extends ShadowBaseElement {
 
   initialize(
     caseId: string,
-    sampleIds: string[],
+    _sampleIds: string[],
     caseURL: string,
     version: string,
   ) {

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -272,7 +272,6 @@ export abstract class DataTrack extends CanvasTrack {
   }
 
   renderYAxis(yAxis: Axis) {
-    // const yScale = getLinearScale(yAxis.range, this.getYDim());
     const yScale = this.getYScale();
     const tickSize = getTickSize(yAxis.range);
     const ticks = generateTicks(yAxis.range, tickSize);

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -20,6 +20,7 @@ interface Settings {
   dragSelect: boolean;
   yAxis: {
     range: Rng;
+    reverse: boolean;
   } | null;
 }
 
@@ -150,7 +151,11 @@ export abstract class DataTrack extends CanvasTrack {
     };
     this.getYScale = () => {
       const yRange = this.getYRange();
-      const yScale = getLinearScale(yRange, this.getYDim());
+      const yScale = getLinearScale(
+        yRange,
+        this.getYDim(),
+        settings.yAxis.reverse,
+      );
       return yScale;
     };
 
@@ -267,7 +272,8 @@ export abstract class DataTrack extends CanvasTrack {
   }
 
   renderYAxis(yAxis: Axis) {
-    const yScale = getLinearScale(yAxis.range, this.getYDim());
+    // const yScale = getLinearScale(yAxis.range, this.getYDim());
+    const yScale = this.getYScale();
     const tickSize = getTickSize(yAxis.range);
     const ticks = generateTicks(yAxis.range, tickSize);
 

--- a/assets/js/components/tracks_manager/tracks_manager.ts
+++ b/assets/js/components/tracks_manager/tracks_manager.ts
@@ -203,7 +203,7 @@ export class TracksManager extends ShadowBaseElement {
         `${sampleId} cov`,
         sampleId,
         (sampleId: string) => dataSources.getCovData(sampleId),
-        { startExpanded, yAxis: { range: COV_Y_RANGE } },
+        { startExpanded, yAxis: { range: COV_Y_RANGE, reverse: true } },
         session,
         openTrackContextMenu,
       );
@@ -212,7 +212,7 @@ export class TracksManager extends ShadowBaseElement {
         `${sampleId} baf`,
         sampleId,
         (sampleId: string) => dataSources.getBafData(sampleId),
-        { startExpanded, yAxis: { range: BAF_Y_RANGE } },
+        { startExpanded, yAxis: { range: BAF_Y_RANGE, reverse: true } },
         session,
         openTrackContextMenu,
       );

--- a/assets/js/constants.ts
+++ b/assets/js/constants.ts
@@ -62,6 +62,12 @@ export const SIZES = {
 
 const font = "12px sans-serif";
 
+const TRACK_HEIGHTS = {
+  extraThin: 20,
+  thin: 45,
+  thick: 120,
+}
+
 // FIXME: First step is to gather all constants here
 // FIXME: Then, the content below should be homogenized
 export const STYLE = {
@@ -125,11 +131,7 @@ export const STYLE = {
     textLaneSize: 20,
     backgroundColor: COLORS.white,
     frameLineWidth: 2,
-    trackHeight: {
-      extraThin: 20,
-      thin: 45,
-      thick: 80,
-    },
+    trackHeight: TRACK_HEIGHTS,
   },
   ideogramTrack: {
     endBevelProportion: 0.05,

--- a/assets/js/draw/render_utils.ts
+++ b/assets/js/draw/render_utils.ts
@@ -172,11 +172,13 @@ export function rgbArrayToString(rgbArray: number[]): string {
   return `rgb(${rgbArray[0]},${rgbArray[1]},${rgbArray[2]})`;
 }
 
-/**
- * Builds a function used to map from domain (i.e. nucleotides)
- * to range (i.e. pixels)
- */
-export function getLinearScale(domain: Rng, range: Rng): Scale {
+export function getLinearScale(origDomain: Rng, range: Rng, reverse: boolean = false): Scale {
+
+  let domain = origDomain;
+  if (reverse) {
+    domain = [origDomain[1], origDomain[0]];
+  }
+
   const scale = (pos: number) => {
     return linearScale(pos, domain, range);
   };

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -27,6 +27,7 @@ export async function initCanvases({
   gensApiURL,
   annotationFile: defaultAnnotationName,
   startRegion,
+  version,
 }: {
   caseId: string;
   sampleIds: string[];
@@ -35,6 +36,7 @@ export async function initCanvases({
   gensApiURL: string;
   annotationFile: string;
   startRegion: Region;
+  version: string;
 }) {
   const gensTracks = document.getElementById("gens-tracks") as TracksManager;
 
@@ -46,6 +48,7 @@ export async function initCanvases({
     caseId,
     sampleIds,
     `${scoutBaseURL}/case/case_id/${caseId}`,
+    version,
   );
 
   const inputControls = document.getElementById(

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -469,6 +469,7 @@ interface DragCallbacks {
 
 interface Axis {
   range: Rng;
+  reverse: boolean;
 }
 
 interface RenderSettings {

--- a/gens/__version__.py
+++ b/gens/__version__.py
@@ -1,3 +1,3 @@
 """Gens version info."""
 
-VERSION = "3.1.0"
+VERSION = "4.0.0-dev"

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -95,7 +95,8 @@
             end: endJs,
         },
         // FIXME: This should come from the backend
-        gensApiURL: '{{ gens_api_url }}'
+        gensApiURL: '{{ gens_api_url }}',
+        version: '{{ version }}',
     })
     // draw statis content
     const visualizationContainer = document.getElementById('visualization-container');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "tippy.js": "^6.3.7"
   },
   "name": "gens",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Interactive tool to visualize genomic copy number profiles from WGS data",
   "main": "gens.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "tippy.js": "^6.3.7"
   },
   "name": "gens",
-  "version": "4.0.0",
+  "version": "4.0.0-dev",
   "description": "Interactive tool to visualize genomic copy number profiles from WGS data",
   "main": "gens.ts",
   "scripts": {


### PR DESCRIPTION
* Y axis now goes from low to high
* More compact top bar
* Display Gens version
* Remove the samples (anyway shown in the tracks)

![stylistic_updates](https://github.com/user-attachments/assets/27f0b989-2b83-4225-b9eb-23d701e3df10)
