### PR TITLE
Fixes for overview chart, and various cleanup

### DIFF
--- a/assets/js/components/tracks/band_track.ts
+++ b/assets/js/components/tracks/band_track.ts
@@ -68,8 +68,6 @@ export class BandTrack extends DataTrack {
 
   override draw(renderData: BandTrackData) {
 
-    console.log("New band draw with dimensions", this.dimensions);
-
     const { bands, xRange } = renderData;
     const ntsPerPx = this.getNtsPerPixel(xRange);
     const showDetails = ntsPerPx < STYLE.tracks.zoomLevel.showDetails;

--- a/assets/js/components/tracks/band_track.ts
+++ b/assets/js/components/tracks/band_track.ts
@@ -68,9 +68,13 @@ export class BandTrack extends DataTrack {
 
   override draw(renderData: BandTrackData) {
 
+    console.log("New band draw with dimensions", this.dimensions);
+
     const { bands, xRange } = renderData;
     const ntsPerPx = this.getNtsPerPixel(xRange);
     const showDetails = ntsPerPx < STYLE.tracks.zoomLevel.showDetails;
+
+    this.syncDimensions();
 
     const xScale = getLinearScale(xRange, [
       LEFT_PX_EDGE,

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -237,7 +237,6 @@ export abstract class DataTrack extends CanvasTrack {
   abstract draw(renderData: DotTrackData | BandTrackData): void;
 
   protected drawStart() {
-    // super.syncDimensions();
     const dimensions = this.dimensions;
     renderBackground(this.ctx, dimensions, STYLE.tracks.edgeColor);
 
@@ -334,7 +333,6 @@ export function renderYAxis(
     });
   }
 
-  // const settings = this.getSettings();
   const hideLabel = yAxis.hideLabelOnCollapse && !settings.isExpanded;
   const hideTicks = yAxis.hideTicksOnCollapse && !settings.isExpanded;
 

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -99,7 +99,6 @@ export abstract class DataTrack extends CanvasTrack {
   }
 
   public toggleExpanded() {
-
     const settings = this.getSettings();
     settings.isExpanded = !settings.isExpanded;
     this.updateSettings(settings);
@@ -152,7 +151,6 @@ export abstract class DataTrack extends CanvasTrack {
       height,
     });
 
-    
     this.trackType = trackType;
     this.getSettings = getSettings;
     this.getXRange = getXRange;
@@ -167,11 +165,7 @@ export abstract class DataTrack extends CanvasTrack {
       const yRange = this.getYRange();
       // Screen coordinates starts from the top
       const reverse = true;
-      const yScale = getLinearScale(
-        yRange,
-        this.getYDim(),
-        reverse,
-      );
+      const yScale = getLinearScale(yRange, this.getYDim(), reverse);
       return yScale;
     };
 
@@ -266,7 +260,13 @@ export abstract class DataTrack extends CanvasTrack {
     );
 
     if (this.getSettings().yAxis != null) {
-      this.renderYAxis(this.getSettings().yAxis);
+      renderYAxis(
+        this.ctx,
+        this.getSettings().yAxis,
+        this.getYScale(),
+        this.dimensions,
+        this.getSettings(),
+      );
     }
   }
 
@@ -292,44 +292,53 @@ export abstract class DataTrack extends CanvasTrack {
     }
   }
 
-  renderYAxis(yAxis: Axis) {
-    const yScale = this.getYScale();
-    const tickSize = getTickSize(yAxis.range);
-    const ticks = generateTicks(yAxis.range, tickSize);
-
-    for (const yTick of ticks) {
-      const yPx = yScale(yTick);
-
-      const lineDims = {
-        x1: STYLE.yAxis.width,
-        x2: this.dimensions.width,
-        y1: yPx,
-        y2: yPx,
-      };
-
-      drawLine(this.ctx, lineDims, {
-        color: STYLE.colors.lighterGray,
-        dashed: false,
-      });
-    }
-
-    const settings = this.getSettings();
-    const hideLabel = yAxis.hideLabelOnCollapse && !settings.isExpanded;
-    const hideTicks = yAxis.hideTicksOnCollapse && !settings.isExpanded;
-
-    const label = hideLabel ? "" : yAxis.label;
-    const renderTicks = hideTicks ? [] : ticks;
-
-    drawYAxis(this.ctx, renderTicks, yScale, yAxis.range, label);
-  }
-
   drawTrackLabel(shiftRight: number = 0): Box {
     return drawLabel(
       this.ctx,
       this.label,
       STYLE.tracks.textPadding + shiftRight,
       STYLE.tracks.textPadding,
-      { textBaseline: "top", boxStyle: { fillColor: `${COLORS.white}${TRANSPARENCY.s}` } },
+      {
+        textBaseline: "top",
+        boxStyle: { fillColor: `${COLORS.white}${TRANSPARENCY.s}` },
+      },
     );
   }
+}
+
+export function renderYAxis(
+  ctx: CanvasRenderingContext2D,
+  yAxis: Axis,
+  yScale: Scale,
+  dimensions: Dimensions,
+  settings: { isExpanded?: boolean },
+) {
+  // const yScale = this.getYScale();
+  const tickSize = getTickSize(yAxis.range);
+  const ticks = generateTicks(yAxis.range, tickSize);
+
+  for (const yTick of ticks) {
+    const yPx = yScale(yTick);
+
+    const lineDims = {
+      x1: STYLE.yAxis.width,
+      x2: dimensions.width,
+      y1: yPx,
+      y2: yPx,
+    };
+
+    drawLine(ctx, lineDims, {
+      color: STYLE.colors.lighterGray,
+      dashed: false,
+    });
+  }
+
+  // const settings = this.getSettings();
+  const hideLabel = yAxis.hideLabelOnCollapse && !settings.isExpanded;
+  const hideTicks = yAxis.hideTicksOnCollapse && !settings.isExpanded;
+
+  const label = hideLabel ? "" : yAxis.label;
+  const renderTicks = hideTicks ? [] : ticks;
+
+  drawYAxis(ctx, renderTicks, yScale, yAxis.range, label);
 }

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -236,7 +236,7 @@ export abstract class DataTrack extends CanvasTrack {
   abstract draw(renderData: DotTrackData | BandTrackData): void;
 
   protected drawStart() {
-    super.syncDimensions();
+    // super.syncDimensions();
     const dimensions = this.dimensions;
     renderBackground(this.ctx, dimensions, STYLE.tracks.edgeColor);
 

--- a/assets/js/components/tracks/base_tracks/data_track.ts
+++ b/assets/js/components/tracks/base_tracks/data_track.ts
@@ -213,6 +213,7 @@ export abstract class DataTrack extends CanvasTrack {
       async () => {
         this.renderSeq = this.renderSeq + 1;
         const mySeq = this.renderSeq;
+        this.renderLoading();
         this.renderData = await this.getRenderData();
         if (mySeq !== this.renderSeq) {
           return;

--- a/assets/js/components/tracks/dot_track.ts
+++ b/assets/js/components/tracks/dot_track.ts
@@ -48,6 +48,7 @@ export class DotTrack extends DataTrack {
   }
 
   override draw(renderData: DotTrackData) {
+    super.syncDimensions();
     super.drawStart();
 
     const { dots } = renderData;

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -1,4 +1,4 @@
-import { drawLabel, drawLine } from "../../draw/shapes";
+import { drawBox, drawLabel, drawLine } from "../../draw/shapes";
 import { transformMap, padRange, generateID } from "../../util/utils";
 import { COLORS, STYLE } from "../../constants";
 import { CanvasTrack, CanvasTrackSettings } from "./base_tracks/canvas_track";
@@ -9,6 +9,8 @@ import {
   renderBackground,
 } from "../../draw/render_utils";
 import { GensMarker } from "../../movements/marker";
+import { COV_Y_RANGE } from "../tracks_manager/tracks_manager";
+import { renderYAxis } from "./base_tracks/data_track";
 
 const X_PAD = 5;
 const DOT_SIZE = 2;
@@ -30,6 +32,7 @@ export class OverviewTrack extends CanvasTrack {
   marker: GensMarker;
   onChromosomeClick: (chrom: string) => void;
   yRange: Rng;
+  yAxis: Axis;
 
   pxRanges: Record<string, Rng> = {};
 
@@ -53,6 +56,7 @@ export class OverviewTrack extends CanvasTrack {
     getRenderData: () => Promise<OverviewTrackData>,
     getRegion: () => Region,
     drawLabels: boolean,
+    yAxis: Axis,
   ) {
     super(id, label, settings);
 
@@ -62,6 +66,7 @@ export class OverviewTrack extends CanvasTrack {
     this.getRegion = getRegion;
     this.onChromosomeClick = onChromosomeClick;
     this.drawLabels = drawLabels;
+    this.yAxis = yAxis;
 
     this.staticBuffer = document.createElement("canvas");
     this.staticCtx = this.staticBuffer.getContext("2d");
@@ -83,10 +88,20 @@ export class OverviewTrack extends CanvasTrack {
     this.canvas.addEventListener("mousedown", (event) => {
       event.stopPropagation();
       const chrom = pixelToChrom(event.offsetX, this.pxRanges);
+      if (chrom == null) {
+        return;
+      }
       this.onChromosomeClick(chrom);
     });
 
-    this.trackContainer.style.cursor = "pointer";
+    this.addElementListener(
+      this.trackContainer,
+      "mousemove",
+      (event: MouseEvent) => {
+        this.trackContainer.style.cursor =
+          event.offsetX > STYLE.yAxis.width ? "pointer" : "";
+      },
+    );
   }
 
   async render(settings: RenderSettings) {
@@ -125,7 +140,8 @@ export class OverviewTrack extends CanvasTrack {
         this.renderData.dotsPerChrom,
         this.chromSizes,
         this.drawLabels,
-        this.dimensions.height,
+        this.dimensions,
+        this.yAxis,
       );
     }
 
@@ -166,7 +182,11 @@ function calculateMetrics(
     0,
   );
   const xScale = (pos: number) => {
-    return linearScale(pos, [0, totalChromSize], [0, dim.width]);
+    return linearScale(
+      pos,
+      [0, totalChromSize],
+      [STYLE.yAxis.width, dim.width],
+    );
   };
   const chromRanges = getChromRanges(chromSizes);
   const pxRanges: Record<string, Rng> = transformMap(
@@ -205,13 +225,22 @@ function renderOverviewPlot(
   dotsPerChrom: Record<string, RenderDot[]>,
   chromSizes: Record<string, number>,
   drawLabels: boolean,
-  height: number,
+  dimensions: Dimensions,
+  yAxis: Axis,
 ) {
+  // Draw the y axis
+  drawBox(
+    ctx,
+    { x1: 0, x2: STYLE.yAxis.width, y1: 0, y2: dimensions.height },
+    { fillColor: COLORS.extraLightGray },
+  );
+  renderYAxis(ctx, yAxis, yScale, dimensions, { isExpanded: true });
+
   // Draw the initial lines
   Object.values(pxRanges).forEach(([_chromPxStart, chromPxEnd]) => {
     drawLine(
       ctx,
-      { x1: chromPxEnd, x2: chromPxEnd, y1: 0, y2: height },
+      { x1: chromPxEnd, x2: chromPxEnd, y1: 0, y2: dimensions.height },
       { color: COLORS.lightGray },
     );
   });
@@ -261,12 +290,19 @@ function renderOverviewPlot(
   });
 }
 
-function pixelToChrom(xPixel: number, pxRanges: Record<string, Rng>): string {
+function pixelToChrom(
+  xPixel: number,
+  pxRanges: Record<string, Rng>,
+): string | null {
+  if (xPixel < pxRanges["1"][0]) {
+    return null;
+  }
   for (const [chrom, range] of Object.entries(pxRanges)) {
     if (xPixel >= range[0] && xPixel < range[1]) {
       return chrom;
     }
   }
+
   throw Error(
     `Something went wrong, no chromosome range matched position: ${xPixel}`,
   );

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -9,7 +9,6 @@ import {
   renderBackground,
 } from "../../draw/render_utils";
 import { GensMarker } from "../../movements/marker";
-import { COV_Y_RANGE } from "../tracks_manager/tracks_manager";
 import { renderYAxis } from "./base_tracks/data_track";
 
 const X_PAD = 5;

--- a/assets/js/components/tracks_manager/track_view.ts
+++ b/assets/js/components/tracks_manager/track_view.ts
@@ -172,6 +172,19 @@ export class TrackView extends ShadowBaseElement {
       },
     );
 
+    const yAxisCov = {
+      range: COV_Y_RANGE,
+      label: "Log2 Ratio",
+      hideLabelOnCollapse: false,
+      hideTicksOnCollapse: false,
+    };
+    const yAxisBaf = {
+      range: BAF_Y_RANGE,
+      label: "B Allele Freq",
+      hideLabelOnCollapse: false,
+      hideTicksOnCollapse: false,
+    };
+
     const overviewTrackCov = createOverviewTrack(
       "overview_cov",
       "Overview (cov)",
@@ -180,6 +193,7 @@ export class TrackView extends ShadowBaseElement {
       chromSizes,
       chromClick,
       session,
+      yAxisCov,
     );
 
     const overviewTrackBaf = createOverviewTrack(
@@ -190,6 +204,7 @@ export class TrackView extends ShadowBaseElement {
       chromSizes,
       chromClick,
       session,
+      yAxisBaf,
     );
 
     this.overviewTracks = [overviewTrackBaf, overviewTrackCov];

--- a/assets/js/components/tracks_manager/track_view.ts
+++ b/assets/js/components/tracks_manager/track_view.ts
@@ -178,13 +178,6 @@ export class TrackView extends ShadowBaseElement {
       hideLabelOnCollapse: false,
       hideTicksOnCollapse: false,
     };
-    const yAxisBaf = {
-      range: BAF_Y_RANGE,
-      label: "B Allele Freq",
-      hideLabelOnCollapse: false,
-      hideTicksOnCollapse: false,
-    };
-
     const overviewTrackCov = createOverviewTrack(
       "overview_cov",
       "Overview (cov)",
@@ -196,6 +189,12 @@ export class TrackView extends ShadowBaseElement {
       yAxisCov,
     );
 
+    const yAxisBaf = {
+      range: BAF_Y_RANGE,
+      label: "B Allele Freq",
+      hideLabelOnCollapse: false,
+      hideTicksOnCollapse: false,
+    };
     const overviewTrackBaf = createOverviewTrack(
       "overview_baf",
       "Overview (baf)",

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -11,6 +11,7 @@ import {
 } from "../util/menu_content_utils";
 import { getSimpleButton } from "../util/menu_utils";
 import { TrackViewTrackInfo } from "./track_view";
+import { BAF_Y_RANGE, COV_Y_RANGE } from "./tracks_manager";
 
 const trackHeight = STYLE.tracks.trackHeight;
 
@@ -249,11 +250,14 @@ export function createOverviewTrack(
   chromSizes: Record<string, number>,
   chromClick: (chrom: string) => void,
   session: GensSession,
+  yAxis: Axis,
 ): OverviewTrack {
+
+
   const overviewTrack = new OverviewTrack(
     id,
     label,
-    { height: trackHeight.l },
+    { height: trackHeight.xl },
     chromSizes,
     chromClick,
     yRange,
@@ -274,6 +278,7 @@ export function createOverviewTrack(
       };
     },
     true,
+    yAxis,
   );
   return overviewTrack;
 }

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -11,7 +11,6 @@ import {
 } from "../util/menu_content_utils";
 import { getSimpleButton } from "../util/menu_utils";
 import { TrackViewTrackInfo } from "./track_view";
-import { BAF_Y_RANGE, COV_Y_RANGE } from "./tracks_manager";
 
 const trackHeight = STYLE.tracks.trackHeight;
 
@@ -252,8 +251,6 @@ export function createOverviewTrack(
   session: GensSession,
   yAxis: Axis,
 ): OverviewTrack {
-
-
   const overviewTrack = new OverviewTrack(
     id,
     label,

--- a/assets/js/constants.ts
+++ b/assets/js/constants.ts
@@ -2,6 +2,7 @@
 // Component specific info goes into the STYLE constant
 
 export const ZINDICES = {
+  trackMarkers: 1000,
   sideMenu: 2000,
 }
 

--- a/assets/js/movements/marker.ts
+++ b/assets/js/movements/marker.ts
@@ -1,5 +1,5 @@
 import { ShadowBaseElement } from "../components/util/shadowbaseelement";
-import { COLORS, SIZES, STYLE } from "../constants";
+import { COLORS, SIZES, STYLE, ZINDICES } from "../constants";
 import { rangeSize, sortRange } from "../util/utils";
 
 const style = STYLE.menu;
@@ -13,7 +13,7 @@ template.innerHTML = String.raw`
       top: 0;
       display: flex;
       pointer-events: none;
-      z-index: 10000;
+      z-index: ${ZINDICES.trackMarkers};
       background-color: ${COLORS.transparentYellow};
     }
     #close {

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -2,7 +2,7 @@ import { CHROMOSOMES } from "../constants";
 import { get } from "../util/fetch";
 import { zip } from "../util/utils";
 
-const CACHED_ZOOM_LEVELS = ["o", "a", "b"];
+const CACHED_ZOOM_LEVELS = ["o", "a", "b", "c"];
 
 export class API {
   genomeBuild: number;


### PR DESCRIPTION
* Overview chart is higher to match old Gens
* Y axis / tick lines for overview charts
* Zoom level "c" is cached
* Marker z level is set between the tracks container and the sidebar
* Always show render on loading for dot and band tracks (previously it showed a frozen picture of the previous state)