### PR TITLE
Fix incorrect variant links

### DIFF
--- a/assets/js/components/tracks/base_tracks/canvas_track.ts
+++ b/assets/js/components/tracks/base_tracks/canvas_track.ts
@@ -5,7 +5,6 @@ import {
   setupCanvasClick,
   getCanvasHover,
 } from "../../util/canvas_interaction";
-import { STYLE } from "../../../constants";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`

--- a/assets/js/components/tracks/overview_track.ts
+++ b/assets/js/components/tracks/overview_track.ts
@@ -15,16 +15,6 @@ const X_PAD = 5;
 const DOT_SIZE = 2;
 const PIXEL_RATIO = 2;
 
-interface Metrics {
-  xRange: Rng;
-  xScale: Scale;
-  yScale: Scale;
-  chromRanges: Record<string, Rng>;
-  viewPxRange: Rng;
-  chromStartPos: number;
-  pxRanges: Record<string, Rng>;
-}
-
 export class OverviewTrack extends CanvasTrack {
   totalChromSize: number;
   chromSizes: Record<string, number>;

--- a/assets/js/components/tracks_manager/track_view.ts
+++ b/assets/js/components/tracks_manager/track_view.ts
@@ -560,7 +560,11 @@ function createSampleTracks(
     `${sample.sampleId} Variants`,
     () => dataSources.getVariantBands(sample, session.getChromosome()),
     (documentId: string) =>
-      dataSources.getVariantDetails(sample, documentId, session.getChromosome()),
+      dataSources.getVariantDetails(
+        sample,
+        documentId,
+        session.getChromosome(),
+      ),
     (variantId: string) => session.getVariantURL(variantId),
     session,
     openTrackContextMenu,

--- a/assets/js/components/tracks_manager/track_view.ts
+++ b/assets/js/components/tracks_manager/track_view.ts
@@ -559,8 +559,8 @@ function createSampleTracks(
     `${sample.sampleId}_variants`,
     `${sample.sampleId} Variants`,
     () => dataSources.getVariantBands(sample, session.getChromosome()),
-    (variantId: string) =>
-      dataSources.getVariantDetails(sample, variantId, session.getChromosome()),
+    (documentId: string) =>
+      dataSources.getVariantDetails(sample, documentId, session.getChromosome()),
     (variantId: string) => session.getVariantURL(variantId),
     session,
     openTrackContextMenu,

--- a/assets/js/components/tracks_manager/tracks_manager.ts
+++ b/assets/js/components/tracks_manager/tracks_manager.ts
@@ -1,4 +1,4 @@
-import { SIZES, STYLE } from "../../constants";
+import { SIZES } from "../../constants";
 import { ShadowBaseElement } from "../util/shadowbaseelement";
 
 import { GensSession } from "../../state/gens_session";

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -126,8 +126,8 @@ export function createVariantTrack(
   id: string,
   label: string,
   dataFn: () => Promise<RenderBand[]>,
-  getVariantDetails: (variantId: string) => Promise<ApiVariantDetails>,
-  getVariantURL: (variantId: string) => string,
+  getVariantDetails: (documentId: string) => Promise<ApiVariantDetails>,
+  getVariantURL: (documentId: string) => string,
   session: GensSession,
   openTrackContextMenu: (track: DataTrack) => void,
 ): BandTrack {
@@ -154,9 +154,10 @@ export function createVariantTrack(
         bands: await dataFn(),
       };
     },
-    async (entryId: string) => {
-      const details = await getVariantDetails(entryId);
-      const scoutUrl = getVariantURL(details.variant_id);
+    async (documentId: string) => {
+      const details = await getVariantDetails(documentId);
+
+      const scoutUrl = getVariantURL(details.document_id);
 
       const button = getSimpleButton("Set highlight", () => {
         session.addHighlight([details.position, details.end]);
@@ -165,7 +166,7 @@ export function createVariantTrack(
       container.appendChild(button);
 
       const entries = getVariantContextMenuContent(
-        entryId,
+        documentId,
         details,
         scoutUrl,
       );

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -156,7 +156,6 @@ export function createVariantTrack(
     },
     async (documentId: string) => {
       const details = await getVariantDetails(documentId);
-
       const scoutUrl = getVariantURL(details.document_id);
 
       const button = getSimpleButton("Set highlight", () => {

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -154,9 +154,9 @@ export function createVariantTrack(
         bands: await dataFn(),
       };
     },
-    async (variantId: string) => {
-      const details = await getVariantDetails(variantId);
-      const scoutUrl = getVariantURL(variantId);
+    async (entryId: string) => {
+      const details = await getVariantDetails(entryId);
+      const scoutUrl = getVariantURL(details.variant_id);
 
       const button = getSimpleButton("Set highlight", () => {
         session.addHighlight([details.position, details.end]);
@@ -165,7 +165,7 @@ export function createVariantTrack(
       container.appendChild(button);
 
       const entries = getVariantContextMenuContent(
-        variantId,
+        entryId,
         details,
         scoutUrl,
       );

--- a/assets/js/gens.ts
+++ b/assets/js/gens.ts
@@ -21,7 +21,7 @@ import { API } from "./state/api";
 import { TracksManager } from "./components/tracks_manager/tracks_manager";
 import { InputControls } from "./components/input_controls";
 import { getRenderDataSource } from "./state/parse_data";
-import { CHROMOSOMES, STYLE } from "./constants";
+import { STYLE } from "./constants";
 import { SideMenu } from "./components/side_menu/side_menu";
 import {
   SettingsMenu,
@@ -31,7 +31,6 @@ import { HeaderInfo } from "./components/header_info";
 import { GensSession } from "./state/gens_session";
 import { GensHome } from "./home/gens_home";
 import { SampleInfo } from "./home/sample_table";
-import { IconButton } from "./components/util/icon_button";
 import { setupShortcuts } from "./shortcuts";
 
 export async function samplesListInit(

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -82,11 +82,11 @@ export class API {
   async getVariantDetails(
     caseId: string,
     sampleId: string,
-    variantId: string,
+    documentId: string,
     currChrom: string,
   ): Promise<ApiVariantDetails> {
     const variants = await this.getVariants(caseId, sampleId, currChrom);
-    const targets = variants.filter((v) => v.variant_id === variantId);
+    const targets = variants.filter((v) => v.document_id === documentId);
     if (targets.length != 1) {
       console.error("Expected a single variant, found: ", targets);
       if (targets.length === 0) {

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -107,8 +107,8 @@ export function getRenderDataSource(
     getTranscriptBands,
     getTranscriptDetails: (id: string) => api.getTranscriptDetails(id),
     getVariantBands,
-    getVariantDetails: (sample: Sample, variantId: string, chrom: string) =>
-      api.getVariantDetails(sample.caseId, sample.sampleId, variantId, chrom),
+    getVariantDetails: (sample: Sample, documentId: string, chrom: string) =>
+      api.getVariantDetails(sample.caseId, sample.sampleId, documentId, chrom),
     getOverviewCovData,
     getOverviewBafData,
   };
@@ -190,7 +190,7 @@ export function parseVariants(
   variantColorMap: VariantColors,
 ): RenderBand[] {
   return variants.map((variant) => {
-    const id = variant.variant_id;
+    const id = variant.document_id;
     return {
       id,
       start: variant.position,


### PR DESCRIPTION
It turned out Scout uses the "document_id" ID for referring to variant pages rather than the "variant_id".