### PR TITLE
Optemise querying of variant information

### DIFF
--- a/assets/js/components/tracks_manager/track_view.ts
+++ b/assets/js/components/tracks_manager/track_view.ts
@@ -544,11 +544,12 @@ function createSampleTracks(
   );
 
   const variantTrack = createVariantTrack(
+    sample.sampleId,
     `${sample.sampleId}_variants`,
     `${sample.sampleId} Variants`,
     () => dataSources.getVariantBands(sample, session.getChromosome()),
     (variantId: string) =>
-      dataSources.getVariantDetails(sample, variantId, session.getChromosome()),
+      dataSources.getVariantDetails(variantId),
     (variantId: string) => session.getVariantURL(variantId),
     session,
     openTrackContextMenu,

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -123,7 +123,8 @@ export function createDotTrack(
 }
 
 export function createVariantTrack(
-  id: string,
+  sampleId: string,
+  trackId: string,
   label: string,
   dataFn: () => Promise<RenderBand[]>,
   getVariantDetails: (variantId: string) => Promise<ApiVariantDetails>,
@@ -142,7 +143,7 @@ export function createVariantTrack(
   };
 
   const variantTrack = new BandTrack(
-    id,
+    trackId,
     label,
     "variant",
     () => fnSettings,
@@ -159,13 +160,14 @@ export function createVariantTrack(
       const scoutUrl = getVariantURL(variantId);
 
       const button = getSimpleButton("Set highlight", () => {
-        session.addHighlight([details.position, details.end]);
+        session.addHighlight([details.start, details.end]);
       });
       const container = document.createElement("div");
       container.appendChild(button);
 
       const entries = getVariantContextMenuContent(
         variantId,
+        sampleId,
         details,
         scoutUrl,
       );

--- a/assets/js/components/util/menu_content_utils.ts
+++ b/assets/js/components/util/menu_content_utils.ts
@@ -2,12 +2,14 @@ import { prefixNts, prettyRange } from "../../util/utils";
 import { getContainer, getEntry, getSection, getURLRow } from "./menu_utils";
 
 export function getVariantContextMenuContent(
-  id: string,
+  trackId: string,
+  sampleId: string,
   details: ApiVariantDetails,
   variantUrl: string,
 ): HTMLDivElement[] {
+  details.sample = details.samples.filter(s => s.sample_id === sampleId)[0]
   const info: { key: string; value: string; url?: string }[] = [
-    { key: "Range", value: `${details.position} - ${details.end}` },
+    { key: "Range", value: `${details.start} - ${details.end}` },
     {
       key: "Length",
       value: prefixNts(details.length),
@@ -43,7 +45,7 @@ export function getVariantContextMenuContent(
       value: `${details.cytoband_start} - ${details.cytoband_end}`,
     },
     { key: "Rank score", value: details.rank_score.toString() },
-    { key: "BNF ID", value: id },
+    { key: "BNF ID", value: trackId },
   ];
 
   const entries: HTMLDivElement[] = info.map((i) => getEntry(i));

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -77,23 +77,14 @@ export class API {
     return details;
   }
 
-  // FIXME: This is a temporary solution. Should really be a detail endpoint in the
-  // backend similarly to the transcripts and the annotations
   async getVariantDetails(
-    caseId: string,
-    sampleId: string,
-    variantId: string,
-    currChrom: string,
+    id: string,
   ): Promise<ApiVariantDetails> {
-    const variants = await this.getVariants(caseId, sampleId, currChrom);
-    const targets = variants.filter((v) => v.variant_id === variantId);
-    if (targets.length != 1) {
-      console.error("Expected a single variant, found: ", targets);
-      if (targets.length === 0) {
-        throw Error("No variant found");
-      }
-    }
-    return targets[0];
+    const details = get(
+      new URL(`tracks/variants/${id}`, this.apiURI).href, 
+      {},
+    ) as Promise<ApiVariantDetails>;
+    return details;
   }
 
   getAnnotationSources(): Promise<ApiAnnotationTrack[]> {
@@ -237,13 +228,13 @@ export class API {
 
   private variantsSampleChromCache: Record<
     string,
-    Record<string, Promise<ApiVariantDetails[]>>
+    Record<string, Promise<ApiSimplifiedVariant[]>>
   > = {};
   getVariants(
     caseId: string,
     sampleId: string,
     chrom: string,
-  ): Promise<ApiVariantDetails[]> {
+  ): Promise<ApiSimplifiedVariant[]> {
     if (this.variantsSampleChromCache[sampleId] == null) {
       this.variantsSampleChromCache[sampleId] = {};
     }
@@ -259,27 +250,28 @@ export class API {
         start: 1,
       };
       const url = new URL("tracks/variants", this.apiURI).href;
-      const variants = get(url, query).then((variants) => {
-        const typedVariants = variants as ApiVariantDetails[];
-        const filteredVariants = typedVariants
-          .map((variant) => {
-            const sampleCallInfo = variant.samples.find(
-              (sample) => sample.sample_id == sampleId,
-            );
-            variant.sample = sampleCallInfo;
-            return variant;
-          })
-          .filter((variant) => {
-            const sample = variant.sample;
+      const variants = get(url, query) as Promise<ApiSimplifiedVariant[]>;
+      // const variants = get(url, query).then((variants) => {
+      //   const typedVariants = variants as ApiSimplifiedVariant[];
+      //   const filteredVariants = typedVariants
+      //     .map(variant => {
+      //       const sampleCallInfo = variant.samples.find(
+      //         (sample) => sample.sample_id == sampleId,
+      //       );
+      //       variant.sample = sampleCallInfo;
+      //       return variant;
+      //     })
+      //     .filter((variant) => {
+      //       const sample = variant.sample;
 
-            return (
-              sample != null &&
-              sample.genotype_call != "0/0" &&
-              sample.genotype_call != "./."
-            );
-          });
-        return filteredVariants;
-      });
+      //       return (
+      //         sample != null &&
+      //         sample.genotype_call != "0/0" &&
+      //         sample.genotype_call != "./."
+      //       );
+      //     });
+      //   return filteredVariants;
+      // });
       // FIXME: Temporary fix until backend is in place
       this.variantsSampleChromCache[sampleId][chrom] = variants;
     }

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -63,7 +63,7 @@ export class API {
 
   getAnnotationDetails(id: string): Promise<ApiAnnotationDetails> {
     const details = get(
-      new URL(`tracks/annotations/annotation/${id}`, this.apiURI).href,
+      new URL(`tracks/annotations/${id}`, this.apiURI).href,
       {},
     ) as Promise<ApiAnnotationDetails>;
     return details;
@@ -71,7 +71,7 @@ export class API {
 
   getTranscriptDetails(id: string): Promise<ApiGeneDetails> {
     const details = get(
-      new URL(`tracks/transcripts/transcript/${id}`, this.apiURI).href,
+      new URL(`tracks/transcripts/${id}`, this.apiURI).href,
       {},
     ) as Promise<ApiGeneDetails>;
     return details;

--- a/assets/js/state/parse_data.ts
+++ b/assets/js/state/parse_data.ts
@@ -107,8 +107,8 @@ export function getRenderDataSource(
     getTranscriptBands,
     getTranscriptDetails: (id: string) => api.getTranscriptDetails(id),
     getVariantBands,
-    getVariantDetails: (sample: Sample, variantId: string, chrom: string) =>
-      api.getVariantDetails(sample.caseId, sample.sampleId, variantId, chrom),
+    getVariantDetails: (id: string) =>
+      api.getVariantDetails(id),
     getOverviewCovData,
     getOverviewBafData,
   };
@@ -186,16 +186,17 @@ export function parseTranscripts(
 }
 
 export function parseVariants(
-  variants: ApiVariantDetails[],
+  variants: ApiSimplifiedVariant[],
   variantColorMap: VariantColors,
 ): RenderBand[] {
   return variants.map((variant) => {
     const id = variant.variant_id;
+    const length = variant.end - variant.start;
     return {
       id,
-      start: variant.position,
+      start: variant.start,
       end: variant.end,
-      hoverInfo: `${variant.sub_category} (${prefixNts(variant.length)})`,
+      hoverInfo: `${variant.sub_category} (${prefixNts(length)})`,
       label: `${variant.variant_type} ${variant.sub_category}`,
       color:
         variantColorMap[variant.sub_category] != undefined

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -1,3 +1,22 @@
+enum VariantCategory {
+  SV = "sv",
+  SNV = "snv",
+  STR = "str",
+}
+
+enum VariantSubCategory {
+  SNV = "snv",
+  INDEL = "indel",
+  DEL = "del",
+  INS = "ins",
+  DUP = "dup",
+  INV = "inv",
+  CNV = "cnv",
+  BND = "bnd",
+  STR = "str",
+  MEI = "mei",
+}
+
 interface ApiAnnotationTrack {
   track_id: string;
   name: string;
@@ -100,11 +119,20 @@ interface ApiSample {
   genotype_quality: number,
 }
 
+interface ApiSimplifiedVariant {
+  variant_id: string;
+  start: number;
+  end: number;
+  variant_type: string;  // e.g. research, clinical
+  category: VariantCategory;
+  sub_category: VariantSubCategory;
+}
+
 interface ApiVariantDetails {
   alternative: string;
   cadd_score: string;
   case_id: string;
-  category: string;
+  category: VariantCategory;
   chromosome: string;
   cytoband_start: string;
   cytoband_end: string;
@@ -123,7 +151,7 @@ interface ApiVariantDetails {
   panels: string[];
   phast_conservation: string[];
   phylop_conservation: string[];
-  position: number;
+  start: number;
   quality: number;
   rank_score: number;
   rank_score_results: { category: string; score: number }[];
@@ -131,7 +159,7 @@ interface ApiVariantDetails {
   sample?: ApiSample;
   samples: ApiSample[];
   simple_id: string;
-  sub_category: string;
+  sub_category: VariantSubCategory;
   variant_id: string;
   variant_rank: number;
   variant_type: string;
@@ -273,12 +301,7 @@ interface RenderDataSource {
   getTranscriptDetails: (geneId: string) => Promise<ApiGeneDetails>;
 
   getVariantBands: (sample: Sample, chrom: string) => Promise<RenderBand[]>;
-  getVariantDetails: (
-    sample: Sample,
-    variantId: string,
-    // FIXME: Temporary workaround due to lacking backend point requires chrom also here
-    chrom: string,
-  ) => Promise<ApiVariantDetails>;
+  getVariantDetails: (variantId: string) => Promise<ApiVariantDetails>;
 
   getOverviewCovData: (sample: Sample) => Promise<Record<string, RenderDot[]>>;
   getOverviewBafData: (sample: Sample) => Promise<Record<string, RenderDot[]>>;

--- a/gens/crud/scout.py
+++ b/gens/crud/scout.py
@@ -2,13 +2,20 @@
 
 import logging
 from typing import Any
+from pydantic import ValidationError
 
 from pymongo.database import Database
 
+from gens.models.annotation import SimplifiedVariantRecord, VariantRecord
 from gens.models.genomic import GenomicRegion, VariantCategory
 
 LOG = logging.getLogger(__name__)
 
+class VariantValidaitonError(Exception):
+    ...
+
+class VariantNotFoundError(Exception):
+    ...
 
 def get_variants(
     case_id: str,
@@ -16,7 +23,7 @@ def get_variants(
     region: GenomicRegion,
     variant_category: VariantCategory,
     db: Database[Any],
-) -> Any:
+) -> list[SimplifiedVariantRecord]:
     """Search the scout database for variants associated with a case.
 
     case_id :: id for a case
@@ -42,6 +49,28 @@ def get_variants(
             **query,
             **query_genomic_region(region.start, region.end, variant_category),  # type: ignore
         }
+    projection: dict[str, bool] = {}
     # query database
     LOG.info("Query variant database: %s", query)
-    return db.get_collection("variant").find(query)
+    try:
+        result: list[SimplifiedVariantRecord] = [
+            SimplifiedVariantRecord.model_validate(doc) for doc in
+            db.get_collection("variant").find(query, projection)]
+    except ValidationError as e:
+        LOG.error("Failed to validate variant data: %s", e)
+        raise VariantValidaitonError("Invalid variant data in Scout database")
+    return result
+
+
+def get_variant(variant_id: str, db: Database[Any]) -> VariantRecord:
+    """Get detailed variant info for one variant from the scout database."""
+    raw_variant = db.get_collection("variant").find_one({"variant_id": variant_id}, {'_id': False})
+    if raw_variant is None:
+        LOG.warning("Variant with id %s not found in scout database", variant_id)
+        raise VariantNotFoundError(f"Variant with id {variant_id} is not found in Scout database")
+    try:
+        variant = VariantRecord.model_validate(raw_variant)
+    except ValidationError as e:
+        LOG.error("Failed to validate variant %s: %s", variant_id, e)
+        raise VariantValidaitonError(f"Invalid variant data for ID {variant_id}")
+    return variant

--- a/gens/models/annotation.py
+++ b/gens/models/annotation.py
@@ -173,7 +173,7 @@ class SimplifiedVariantRecord(RWModel):
     """Simplified variant info for rendering variant track."""
     
     variant_id: str
-    start: PositiveInt
+    position: PositiveInt = Field(..., description="Start position of the variant", alias="start")
     end: PositiveInt
     variant_type: str
     sub_category: str | None = None
@@ -196,7 +196,7 @@ class VariantRecord(RWModel):
     mate_id: str | None = None # For SVs this identifies the other end
     case_id: str  # case_id is a string like owner_caseid
     chromosome: str  # required
-    position: int  # required
+    position: PositiveInt = Field(..., description="Start position of the variant", alias="start")  
     end: int  # required
     length: int  # required
     reference: str  # required
@@ -213,7 +213,7 @@ class VariantRecord(RWModel):
     genetic_models: list[str] = []  # list of strings choices=GENETIC_MODELS
     compounds: list[dict[str, Any]] = [] # sorted list of <compound> ordering='combined_score'
     genes: list[dict[str, Any]] = [] # list with <gene>
-    dbsnp_id: str
+    dbsnp_id: str | None = None  # dbsnp id, if available
     # Gene ids:
     hgnc_ids: list[int] = [] # list of hgnc ids (int)
     hgnc_symbols: list[str] = [] # list of hgnc symbols (str)

--- a/gens/models/genomic.py
+++ b/gens/models/genomic.py
@@ -3,7 +3,7 @@
 import re
 from enum import Enum, IntEnum, StrEnum
 
-from pydantic import TypeAdapter, computed_field, field_validator
+from pydantic import computed_field, field_validator
 from pydantic.types import PositiveFloat, PositiveInt
 
 from .base import RWModel

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -5,7 +5,6 @@ Query individual annotaions or transcript to get the full info.
 """
 
 from http import HTTPStatus
-from typing import Any
 from fastapi import APIRouter, HTTPException
 
 from gens.constants import MANE_PLUS_CLINICAL, MANE_SELECT
@@ -15,7 +14,9 @@ from gens.models.annotation import (
     AnnotationTrackInDb,
     SimplifiedTrackInfo,
     SimplifiedTranscriptInfo,
+    SimplifiedVariantRecord,
     TranscriptRecord,
+    VariantRecord,
 )
 from gens.models.genomic import (
     ChromInfo,
@@ -28,7 +29,7 @@ from gens.models.genomic import (
 from gens.models.base import PydanticObjectId
 from gens.crud.genomic import get_chromosome_info, get_chromosomes
 from gens.crud.transcripts import get_transcript, get_transcripts as crud_get_transcripts
-from gens.crud.scout import get_variants as get_variants_from_scout
+from gens.crud.scout import VariantNotFoundError, VariantValidaitonError, get_variant, get_variants as get_variants_from_scout
 
 from .utils import ApiTags, GensDb, ScoutDb
 
@@ -50,7 +51,7 @@ async def get_annotation_track(track_id: PydanticObjectId, db: GensDb) -> list[S
     return get_annotations_for_track(track_id=track_id, db=db)
 
 
-@router.get("/annotations/annotation/{record_id}", tags=[ApiTags.ANNOT])
+@router.get("/annotations/{record_id}", tags=[ApiTags.ANNOT])
 async def get_annotation_with_id(record_id: PydanticObjectId, db: GensDb) -> AnnotationRecord:
     """Get annotations for a region."""
     result = get_annotation(record_id, db)
@@ -68,9 +69,9 @@ async def get_transcripts(
     end: int | None = None,
     only_mane: bool = False,
 ) -> list[SimplifiedTranscriptInfo]:
-    """Get all transcripts for a sample.
+    """Get all transcripts for a genomic region.
 
-    Return reduced information.
+    Returns a list of simplified transcript records. Use query parameters to filter by region or type.
     """
     # lookup end of chromosome if no end is defined and calculate zoom level
     start = start if start is not None else 1
@@ -92,9 +93,12 @@ async def get_transcripts(
     return transcripts
 
 
-@router.get("/transcripts/transcript/{transcript_id}", tags=[ApiTags.TRANSC])
+@router.get("/transcripts/{transcript_id}", tags=[ApiTags.TRANSC])
 async def get_transcript_with_id(transcript_id: PydanticObjectId, db: GensDb) -> TranscriptRecord:
-    """Query the database for a transcript and return the full info."""
+    """Get a single transcript by its unique ID.
+
+    Returns the full transcript record with all available details.
+    """
     result = get_transcript(transcript_id, db)
     if result is None:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND)


### PR DESCRIPTION
This PR changes how variants are queried to align with the pattern for querying transcripts and annotations, i.e.
- GET `/variants` => list of simplified variant information for rendering tracks
- GET `/variants/{variant_id}` => detailed variant information