### PR TITLE
Cache coverage on demand

### DIFF
--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -392,33 +392,6 @@ async function getCovData(
   return parsedResult;
 }
 
-// function getDataPerZoom(
-//   chrom: string,
-//   zoomLevels: string[],
-//   endpoint: string,
-//   sampleId: string,
-//   caseId: string,
-//   apiURI: string,
-//   chromSizes: Record<string, number>,
-// ): Record<string, Promise<ApiCoverageDot[]>> {
-//   const dataPerZoom: Record<string, Promise<ApiCoverageDot[]>> = {};
-
-//   for (const zoom of zoomLevels) {
-//     const parsedResult = getCovData(
-//       apiURI,
-//       endpoint,
-//       sampleId,
-//       caseId,
-//       chrom,
-//       zoom,
-//       [1, chromSizes[chrom]],
-//     );
-//     dataPerZoom[zoom] = parsedResult;
-//   }
-
-//   return dataPerZoom;
-// }
-
 async function getOverviewData(
   sampleId: string,
   caseId: string,


### PR DESCRIPTION
Previously, multiple zoom levels were cached when initially entering a chromosome. This made it slow to toggle between chromosomes. Now the full chromosome coverage is loaded when initially entering a zoom level for a chromosome.