### PR TITLE
Remove massive data div

### DIFF
--- a/assets/js/home/sample_table.ts
+++ b/assets/js/home/sample_table.ts
@@ -54,7 +54,8 @@ export class SamplesTable extends HTMLElement {
     this.dataTable = new DataTable("#my-table", {
       searchable: true,
       fixedHeight: true,
-      perPage: 20,
+      perPage: 50,
+      perPageSelect: false,      
       labels: { noRows: "Loading..." },
     });
   }

--- a/gens/blueprints/home/templates/home.html
+++ b/gens/blueprints/home/templates/home.html
@@ -18,7 +18,6 @@
 {% block body %}
   {{ navbar('home', version, current_user) }}
   {{ super() }}
-  <div id="data" data-samples="{{ samples | tojson }}"></div>
   <script>
     const samplesJSON = JSON.parse(`{{ samples | tojson }}`);
     // FIXME: Get from the backend


### PR DESCRIPTION
Removes div which unbeknownst stuck all the sample info from 20000 samples into a single div. This in turned ~30 seconds freeze on the samples page.

Seems to be behaving better now.