### PR TITLE
Specific end points for full annotation track info and specific annotation entry

### DIFF
--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -180,7 +180,6 @@ export class InputControls extends HTMLElement {
       // console.log("Search", currentValue);
       queryRegionOrGene(
         currentValue,
-        this.session.getGenomeBuild(),
         (chrom: Chromosome, range?: Rng) => {
           this.session.setChromosome(chrom, range);
           this.onChange({ dataUpdated: true, positionOnly: true });
@@ -251,23 +250,24 @@ export class InputControls extends HTMLElement {
 
 async function queryRegionOrGene(
   query: string,
-  genomeBuild: number,
   onChangePosition: (chrom: string, range?: Rng) => void,
   getSearchResult: (string) => Promise<ApiSearchResult | null>,
 ) {
+  let chrom: Chromosome;
+  let range: Rng | undefined = undefined;
   if (query.includes(":")) {
-    const [chrom, rangeStr] = query.split(":");
-    const range = rangeStr.split("-").map((val) => parseInt(val)) as Rng;
-    onChangePosition(chrom, range);
+    const parts = query.split(":");
+    chrom = parts[0] as Chromosome;
+    range = parts[1].split("-").map((val) => parseInt(val)) as Rng;
   } else if (CHROMOSOMES.includes(query as Chromosome)) {
-    onChangePosition(query);
+    chrom = query as Chromosome;
   } else {
     const searchResult = await getSearchResult(query);
-    onChangePosition(searchResult.chromosome, [
-      searchResult.start,
-      searchResult.end,
-    ]);
+    chrom = searchResult.chromosome as Chromosome;
+    range = [searchResult.start, searchResult.end];
   }
+  console.log("Navigating to:", chrom, range);
+  onChangePosition(chrom, range);
 }
 
 customElements.define("input-controls", InputControls);

--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -266,7 +266,6 @@ async function queryRegionOrGene(
     chrom = searchResult.chromosome as Chromosome;
     range = [searchResult.start, searchResult.end];
   }
-  console.log("Navigating to:", chrom, range);
   onChangePosition(chrom, range);
 }
 

--- a/assets/js/state/api.ts
+++ b/assets/js/state/api.ts
@@ -66,7 +66,7 @@ export class API {
 
   getAnnotationDetails(id: string): Promise<ApiAnnotationDetails> {
     const details = get(
-      new URL(`tracks/annotations/${id}`, this.apiURI).href,
+      new URL(`tracks/annotations/record/${id}`, this.apiURI).href,
       {},
     ) as Promise<ApiAnnotationDetails>;
     return details;
@@ -100,7 +100,7 @@ export class API {
     if (this.annotsCache[trackId] === undefined) {
       const query = {};
       const annotations = get(
-        new URL(`tracks/annotations/${trackId}`, this.apiURI).href,
+        new URL(`tracks/annotations/track/${trackId}`, this.apiURI).href,
         query,
       ) as Promise<ApiSimplifiedAnnotation[]>;
 

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -45,18 +45,20 @@ async def get_annotations_tracks(
     return tracks
 
 
-@router.get("/annotations/{track_id}", tags=[ApiTags.ANNOT])
+@router.get("/annotations/track/{track_id}", tags=[ApiTags.ANNOT])
 async def get_annotation_track(track_id: PydanticObjectId, db: GensDb) -> list[SimplifiedTrackInfo]:
     """Get annotations for a region."""
+    print("Hitting the track")
     return get_annotations_for_track(track_id=track_id, db=db)
 
 
-@router.get("/annotations/{record_id}", tags=[ApiTags.ANNOT])
+@router.get("/annotations/record/{record_id}", tags=[ApiTags.ANNOT])
 async def get_annotation_with_id(record_id: PydanticObjectId, db: GensDb) -> AnnotationRecord:
     """Get annotations for a region."""
     result = get_annotation(record_id, db)
     if result is None:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
+    print("Hitting the record")
     return result
 
 

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -48,7 +48,6 @@ async def get_annotations_tracks(
 @router.get("/annotations/track/{track_id}", tags=[ApiTags.ANNOT])
 async def get_annotation_track(track_id: PydanticObjectId, db: GensDb) -> list[SimplifiedTrackInfo]:
     """Get annotations for a region."""
-    print("Hitting the track")
     return get_annotations_for_track(track_id=track_id, db=db)
 
 
@@ -58,7 +57,6 @@ async def get_annotation_with_id(record_id: PydanticObjectId, db: GensDb) -> Ann
     result = get_annotation(record_id, db)
     if result is None:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
-    print("Hitting the record")
     return result
 
 


### PR DESCRIPTION
Previously they used the same end point, which led to the specific entry requests ending up in the track endpoint instead.