### PR TITLE
Adjust x-range for sample annotation track in chromosome view

### DIFF
--- a/assets/js/components/tracks_manager/chromosome_view.ts
+++ b/assets/js/components/tracks_manager/chromosome_view.ts
@@ -204,6 +204,7 @@ function addSampleAnnotationTracks(
     const bandTrack = createAnnotTrack(
       trackId,
       source.name,
+      () => [1, session.getChromSize("1")],
       () => getBands(source.id, chrom),
       (id: string) => getDetails(id),
       session,

--- a/assets/js/components/tracks_manager/track_view.ts
+++ b/assets/js/components/tracks_manager/track_view.ts
@@ -715,6 +715,7 @@ function updateAnnotationTracks(
     const newTrack = createAnnotTrack(
       source.id,
       source.label,
+      () => session.getXRange(),
       () => getAnnotationBands(source.id, session.getChromosome()),
       (bandId: string) => getAnnotationDetails(bandId),
       session,
@@ -749,6 +750,7 @@ async function getSampleAnnotationTracks(
     const annotTrack = createAnnotTrack(
       sampleAnnotSource.id,
       sampleAnnotSource.name,
+      () => session.getXRange(),
       () => {
         const bands = dataSources.getSampleAnnotationBands(
           sampleAnnotSource.id,

--- a/assets/js/components/tracks_manager/utils.ts
+++ b/assets/js/components/tracks_manager/utils.ts
@@ -20,6 +20,7 @@ export const TRACK_HANDLE_CLASS = "track-handle";
 export function createAnnotTrack(
   trackId: string,
   label: string,
+  getXRange: () => Rng,
   getAnnotationBands: () => Promise<RenderBand[]>,
   getAnnotationDetails: (id: string) => Promise<ApiAnnotationDetails>,
   session: GensSession,
@@ -72,7 +73,7 @@ export function createAnnotTrack(
     (settings) => {
       fnSettings = settings;
     },
-    () => session.getXRange(),
+    () => getXRange(),
     () => getAnnotTrackData(getAnnotationBands),
     openContextMenuId,
     openTrackContextMenu,


### PR DESCRIPTION
Close #432

Previously in the chromosome view, the data adapted to the chromosome size, but the sample annotation did not.