### PR TITLE
Don't block on specific sample types

### DIFF
--- a/assets/js/constants.ts
+++ b/assets/js/constants.ts
@@ -224,10 +224,3 @@ export const CHROMOSOMES: Chromosome[] = [
   "Y",
 ];
 
-export const SAMPLE_TYPES = [
-  "proband",
-  "mother",
-  "father",
-  "tumor",
-  "normal",
-];

--- a/assets/js/util/utils.ts
+++ b/assets/js/util/utils.ts
@@ -345,6 +345,7 @@ export function div(): HTMLDivElement {
   return document.createElement("div") as HTMLDivElement;
 }
 
+// FIXME: These should be replaced with config based deciding of "main" sample
 export function isNonMainSample(sample: Sample): boolean {
   const isNotMainSample =
     sample.sampleType == null ||

--- a/gens/cli/load.py
+++ b/gens/cli/load.py
@@ -110,7 +110,7 @@ def load() -> None:
     "--sample-type",
     type=ChoiceType(SampleType),
     required=False,
-    help="Type of the sample (tumor/normal, proband/mother/father, other)",
+    help="Type of the sample (for instance, tumor/normal, proband/mother/father/relative, other)",
 )
 @click.option(
     "--sex",

--- a/gens/cli/update.py
+++ b/gens/cli/update.py
@@ -44,7 +44,7 @@ def update() -> None:
     "-t",
     "--sample-type",
     type=ChoiceType(SampleType),
-    help="New sample type",
+    help="New sample type (for instance, tumor/normal, proband/mother/father/relative, other)",
 )
 @click.option(
     "--sex",

--- a/gens/models/sample.py
+++ b/gens/models/sample.py
@@ -36,16 +36,6 @@ class ZoomLevel(StrEnum):
     O = "o"
 
 
-class SampleType(StrEnum):
-    """Valid sample types"""
-    TUMOR = "tumor"
-    NORMAL = "normal"
-    PROBAND = "proband"
-    MOTHER = "mother"
-    FATHER = "father"
-    OTHER = "other"
-
-
 class SampleSex(StrEnum):
     """Valid sample sexes."""
 
@@ -91,7 +81,7 @@ class SampleInfo(RWModel, CreatedAtModel):
     baf_file: FilePath
     coverage_file: FilePath
     overview_file: FilePath | None = None
-    sample_type: SampleType | None = None
+    sample_type: str | None = None
     sex: SampleSex | None = None
     meta: list[MetaEntry] = Field(default_factory=list)
 


### PR DESCRIPTION
Previously, only specific sample types were allowed.

This inevitably caused issues with types not included among these.

Better to allow any type, and let the user specify a "main type" through their configuration (or default to proband / tumor).