### PR TITLE
Resolve variant ID issue

### DIFF
--- a/assets/js/state/data_source.ts
+++ b/assets/js/state/data_source.ts
@@ -268,7 +268,7 @@ export function parseTranscripts(
 
 export function parseVariants(variants: ApiSimplifiedVariant[]): RenderBand[] {
   return variants.map((variant) => {
-    const id = variant.variant_id;
+    const id = variant.document_id;
     const length = variant.end - variant.start;
     return {
       id,

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -157,7 +157,7 @@ interface SampleMetaEntry {
 }
 
 interface ApiSimplifiedVariant {
-  variant_id: string;
+  document_id: string;
   start: number;
   end: number;
   variant_type: string; // e.g. research, clinical

--- a/gens/crud/scout.py
+++ b/gens/crud/scout.py
@@ -63,15 +63,15 @@ def get_variants(
     return result
 
 
-def get_variant(variant_id: str, db: Database[Any]) -> VariantRecord:
+def get_variant(document_id: str, db: Database[Any]) -> VariantRecord:
     """Get detailed variant info for one variant from the scout database."""
-    raw_variant = db.get_collection("variant").find_one({"variant_id": variant_id}, {'_id': False})
+    raw_variant = db.get_collection("variant").find_one({"_id": document_id}, {'_id': False})
     if raw_variant is None:
-        LOG.warning("Variant with id %s not found in scout database", variant_id)
-        raise VariantNotFoundError(f"Variant with id {variant_id} is not found in Scout database")
+        LOG.warning("Variant with document_id %s not found in scout database", document_id)
+        raise VariantNotFoundError(f"Variant with id {document_id} is not found in Scout database")
     try:
         variant = VariantRecord.model_validate(raw_variant)
     except ValidationError as e:
-        LOG.error("Failed to validate variant %s: %s", variant_id, e)
-        raise VariantValidaitonError(f"Invalid variant data for ID {variant_id}")
+        LOG.error("Failed to validate variant %s: %s", document_id, e)
+        raise VariantValidaitonError(f"Invalid variant data for ID {document_id}")
     return variant

--- a/gens/models/annotation.py
+++ b/gens/models/annotation.py
@@ -171,7 +171,7 @@ class TranscriptRecord(RWModel):
 class SimplifiedVariantRecord(RWModel):
     """Simplified variant info for rendering variant track."""
     
-    variant_id: str
+    document_id: str
     position: PositiveInt = Field(..., description="Start position of the variant", alias="start")
     end: PositiveInt
     variant_type: str

--- a/gens/routes/annotations.py
+++ b/gens/routes/annotations.py
@@ -176,9 +176,9 @@ async def get_variants(
     return filtered
 
 
-@router.get("/variants/{variant_id}", tags=[ApiTags.VAR])
+@router.get("/variants/{document_id}", tags=[ApiTags.VAR])
 async def get_variant_with_id(
-    variant_id: str,
+    document_id: str,
     db: ScoutDb,
 ) -> VariantRecord:
     """Get a single variant by its unique ID.
@@ -186,11 +186,11 @@ async def get_variant_with_id(
     Returns the full variant record from Scout with all available details.
     """
     try:
-        variant = get_variant(variant_id, db=db)
+        variant = get_variant(document_id, db=db)
     except VariantValidaitonError as e:
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e))
     except VariantNotFoundError:
         raise HTTPException(
-            status_code=HTTPStatus.NOT_FOUND, detail=f"Variant {variant_id} not found"
+            status_code=HTTPStatus.NOT_FOUND, detail=f"Variant {document_id} not found"
         )
     return variant


### PR DESCRIPTION
Before, Gens was querying variants on the `variant_id` field. This can be reused across multiple documents it seems.

Next, I attempted `document_id` field. This froze up the db as this wasn't indexed.

Finally, querying for document ID on `_id` worked out.