### PR TITLE
Remove FlaskGroup dependency

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - mongodb
     environment:
-      - FLASK_ENV=development
+      - FLASK_DEBUG=1
       - AUTHENTICATION=disabled
     ports:
       - 8080:8000

--- a/gens/cli/base.py
+++ b/gens/cli/base.py
@@ -1,10 +1,10 @@
 """Gens command line interface."""
 
 import click
-from flask.cli import FlaskGroup
+# from flask.cli import FlaskGroup
 
 from gens.__version__ import VERSION as version
-from gens.app import create_app
+# from gens.app import create_app
 
 from .delete import delete as delete_command
 from .update import update as update_command
@@ -12,12 +12,7 @@ from .index import index as index_command
 from .load import load as load_command
 
 
-@click.group(
-    cls=FlaskGroup,
-    create_app=create_app,
-    add_default_commands=False,
-    add_version_option=False,
-)
+@click.group()
 @click.version_option(version)
 def cli() -> None:
     """Management of Gens application"""


### PR DESCRIPTION
I started running into warnings when running the Gens CLI.

The flask dependency no longer seems to be needed for the CLI after switching the config file. This seems to have resolved the issues (and also reduced the dependency load).