### PR TITLE
Use A zoom for zoomed out tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - ClinVar IDs (VCV, RCV) are detect in annotation text and automatically made into URLs. (https://github.com/SMD-Bioinformatics-Lund/gens/issues/510)
 
 ### Fixed 
-
  - Coloring of heterozygote variants now uses correct colors. (https://github.com/SMD-Bioinformatics-Lund/gens/issues/504)
+ - Start on zoom-level "a" for tracks instead of showing the overview dots also for the tracks.
 
 ## 4.1.0
 

--- a/frontend/js/state/data_source.ts
+++ b/frontend/js/state/data_source.ts
@@ -5,9 +5,6 @@ import { API } from "./api";
 function calculateZoom(xRange: Rng) {
   const xRangeSize = xRange[1] - xRange[0];
   let returnVal;
-  // if (xRangeSize > 100 * 10 ** 6) {
-  //   returnVal = "o";
-  // } else 
   if (xRangeSize > 50 * 10 ** 6) {
     returnVal = "a";
   } else if (xRangeSize > 10 * 10 ** 6) {

--- a/frontend/js/state/data_source.ts
+++ b/frontend/js/state/data_source.ts
@@ -5,9 +5,10 @@ import { API } from "./api";
 function calculateZoom(xRange: Rng) {
   const xRangeSize = xRange[1] - xRange[0];
   let returnVal;
-  if (xRangeSize > 100 * 10 ** 6) {
-    returnVal = "o";
-  } else if (xRangeSize > 50 * 10 ** 6) {
+  // if (xRangeSize > 100 * 10 ** 6) {
+  //   returnVal = "o";
+  // } else 
+  if (xRangeSize > 50 * 10 ** 6) {
     returnVal = "a";
   } else if (xRangeSize > 10 * 10 ** 6) {
     returnVal = "b";


### PR DESCRIPTION
Previously "o" which apparently were meant for the overview tracks.

Close #496
Close #501
