### PR TITLE
Visual end pad when searching for a gene or annotation

### DIFF
--- a/frontend/js/components/input_controls.ts
+++ b/frontend/js/components/input_controls.ts
@@ -287,9 +287,9 @@ async function queryRegionOrGene(
     chrom = searchResult.chromosome as Chromosome;
 
     // Add visual padding at edges
-    const paddedRange = extendRange([searchResult.start, searchResult.end]);
-
-    onChangePosition(chrom, paddedRange);
+    range = extendRange([searchResult.start, searchResult.end]);
+  }
+  onChangePosition(chrom, range);
 }
 
 function extendRange(startRange: Rng): Rng {
@@ -297,7 +297,7 @@ function extendRange(startRange: Rng): Rng {
   const fracDiff = range * SEARCH_PAD_FRAC;
   const usedStart = Math.ceil(startRange[0] - fracDiff / 2);
   const usedEnd = Math.floor(startRange[1] + fracDiff / 2);
-  return [usedStart, usedEnd]
+  return [usedStart, usedEnd];
 }
 
 customElements.define("input-controls", InputControls);

--- a/frontend/js/components/input_controls.ts
+++ b/frontend/js/components/input_controls.ts
@@ -1,6 +1,13 @@
-import { CHROMOSOMES, COLORS, ICONS, SIZES } from "../constants";
+import {
+  CHROMOSOMES,
+  COLORS,
+  ICONS,
+  SEARCH_PAD_FRAC,
+  SIZES,
+} from "../constants";
 import { GensSession } from "../state/gens_session";
 import { getPan, zoomIn, zoomOut } from "../util/navigation";
+import { rangeSize } from "../util/utils";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`
@@ -184,12 +191,11 @@ export class InputControls extends HTMLElement {
 
     this.infoButton.addEventListener("click", () => {
       this.onOpenInfo();
-    })
+    });
 
     // FIXME: Also enter when inside the input?
     this.searchButton.addEventListener("click", () => {
       const currentValue = this.regionField.value;
-      // console.log("Search", currentValue);
       queryRegionOrGene(
         currentValue,
         (chrom: Chromosome, range?: Rng) => {
@@ -279,9 +285,19 @@ async function queryRegionOrGene(
       return;
     }
     chrom = searchResult.chromosome as Chromosome;
-    range = [searchResult.start, searchResult.end];
-  }
-  onChangePosition(chrom, range);
+
+    // Add visual padding at edges
+    const paddedRange = extendRange([searchResult.start, searchResult.end]);
+
+    onChangePosition(chrom, paddedRange);
+}
+
+function extendRange(startRange: Rng): Rng {
+  const range = rangeSize(startRange);
+  const fracDiff = range * SEARCH_PAD_FRAC;
+  const usedStart = Math.ceil(startRange[0] - fracDiff / 2);
+  const usedEnd = Math.floor(startRange[1] + fracDiff / 2);
+  return [usedStart, usedEnd]
 }
 
 customElements.define("input-controls", InputControls);

--- a/frontend/js/components/input_controls.ts
+++ b/frontend/js/components/input_controls.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants";
 import { GensSession } from "../state/gens_session";
 import { getPan, zoomIn, zoomOut } from "../util/navigation";
-import { rangeSize } from "../util/utils";
+import { clampRange, rangeSize } from "../util/utils";
 
 const template = document.createElement("template");
 template.innerHTML = String.raw`
@@ -287,7 +287,8 @@ async function queryRegionOrGene(
     chrom = searchResult.chromosome as Chromosome;
 
     // Add visual padding at edges
-    range = extendRange([searchResult.start, searchResult.end]);
+    const rawRange = extendRange([searchResult.start, searchResult.end]);
+    range = clampRange(rawRange, 1, this.session.getCurrentChromSize());
   }
   onChangePosition(chrom, range);
 }

--- a/frontend/js/constants.ts
+++ b/frontend/js/constants.ts
@@ -12,6 +12,8 @@ export const ZOOM_STEPS = {
   C: 500 * 10 ** 3,
 }
 
+export const SEARCH_PAD_FRAC = 0.02;
+
 // FIXME: This is hard-coded for the constitutional pipeline
 // Will need to consider how to generalize this for somatic (and micro?)
 export const DEFAULT_VARIANT_THRES = 14;

--- a/frontend/js/util/utils.ts
+++ b/frontend/js/util/utils.ts
@@ -149,6 +149,12 @@ export function padRange(range: Rng, pad: number): Rng {
   return [range[0] + pad, range[1] - pad];
 }
 
+export function clampRange(range: Rng, min: number, max: number): Rng {
+  const clampedMin = Math.max(range[0], min);
+  const clampedMax = Math.min(range[1], max);
+  return [clampedMin, clampedMax]
+}
+
 export function removeChildren(container: HTMLElement) {
   while (container.firstChild) {
     container.removeChild(container.firstChild);


### PR DESCRIPTION
Previously hard to understand that you ended up exactly matching the edges.

Now a slight padding is added to the range when searching for a symbol.

Example RNU4-2 search

<img width="762" height="338" alt="rnu42_search" src="https://github.com/user-attachments/assets/c367bfbb-ac14-4fdb-b296-05cc16de78e3" />

SMN2 search

<img width="759" height="307" alt="smn_search" src="https://github.com/user-attachments/assets/4a2157fd-29f8-4de4-9ef6-a24113e99f95" />

Close #493