### PR TITLE
Same default port for dev and prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Start on zoom-level "a" for tracks instead of showing the overview dots also for the tracks. (https://github.com/SMD-Bioinformatics-Lund/gens/pull/515)
 - Intron numbering OK also for reverse strand transcripts (https://github.com/SMD-Bioinformatics-Lund/gens/pull/539)
 - Boxpadding for sample info drawer, to prevent truncating at the bottom (https://github.com/SMD-Bioinformatics-Lund/gens/pull/539)
+- Fix such that the same Gens port is used for dev and prod configs (5000), avoiding having to reconfigure during release testing (https://github.com/SMD-Bioinformatics-Lund/gens/pull/544)
 
 ## 4.1.0
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,10 +18,10 @@ services:
       - FLASK_DEBUG=1
       - AUTHENTICATION=disabled
     ports:
-      - 8080:8000
+      - 8080:5000
     volumes:
       - ./dump:/dump
       - ./gens:/home/worker/gens
       - ./tests:/home/worker/tests
       - ./utils:/home/worker/utils
-    command: uvicorn gens.app:create_app --reload --log-level debug --host 0.0.0.0
+    command: uvicorn gens.app:create_app --reload --log-level debug --host 0.0.0.0 --port 5000

--- a/gens/config.toml
+++ b/gens/config.toml
@@ -1,6 +1,6 @@
 variant_url = "http://localhost:8000"
 authentication = "disabled"
-gens_api_url = "http://localhost:8080/"
+gens_api_url = "http://localhost:5000/"
 main_sample_types = ["proband", "tumor"]
 
 [gens_db]


### PR DESCRIPTION
Close #467 

Fix such that the same Gens port is used for dev and prod configs (5000), avoiding having to reconfigure during release testing